### PR TITLE
Close 0.7.0 review findings (#42-#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,99 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 with the caveat that **while at 0.x, breaking changes land on the minor version**
 (standard npm semver for pre-1.0 libraries).
 
+## [Unreleased]
+
+Post-release review hardening. Fourteen issues opened against the 0.7.0
+audit (`#42`–`#55`) are all resolved on this branch. No Public-API
+breaking changes; the Connect surface gains two additions
+(`onTokenExpired`, `verifyWebhookSignature`) and a tightened filter-bag
+type. Error `.name` strings are now the `Hospitable*` spec names — code
+that routes on `instanceof` continues to work, code that routes on
+literal `err.name === 'AuthenticationError'` needs to update the string.
+
+### ✨ Added
+
+- **`HospitableConnectClientConfig.onTokenExpired`** (`#42`) — optional
+  callback invoked on a 401 to mint a fresh token. The SDK swaps the
+  token and transparently retries the failing request. Without this
+  hook, 401 remains terminal (previous behavior).
+- **`verifyWebhookSignature`** (`#43`) — HMAC-SHA256 verification helper
+  for incoming Connect webhooks. Uses `crypto.timingSafeEqual`; supports
+  `sha1`/`sha256`, hex/base64 headers, `algo=`-prefixed headers, and an
+  optional timestamped scheme with `toleranceSeconds` anti-replay. Never
+  throws on mismatch (DoS guard); returns `false`. Exported from the
+  `Connect` namespace.
+- **`HospitableForbiddenError`, `HospitableNotFoundError`,
+  `HospitableConfigurationError`** — new `Hospitable*` aliases for the
+  corresponding error classes. `HospitableAuthError` now catches 403
+  too; see below.
+- **`TokenManagerConfig.expiresIn`** (`#54`) — optional TTL (in seconds)
+  for a caller-supplied `token + refreshToken`. Default is 3600 (was a
+  hardcoded 60-second TTL). Pass `expiresIn: 0` to force an immediate
+  refresh on the first request.
+- **`Connect.collectAll`** (`#50`) — re-export of the pagination
+  drain helper for namespace symmetry.
+
+### 🐛 Fixed
+
+- **`HospitableAuthError` covers 403** (`#45`) — `ForbiddenError` now
+  extends `AuthenticationError`, so `err instanceof HospitableAuthError`
+  catches both 401 and 403 per AGENTS.md spec. `ForbiddenError` keeps
+  its own class for fine-grained routing.
+- **Error `.name` matches the spec alias** (`#46`) — every error class
+  now reports its `Hospitable*` name:
+  `HospitableAuthError`, `HospitableRateLimitError`,
+  `HospitableNotFoundError`, `HospitableValidationError`,
+  `HospitableForbiddenError`, `HospitableServerError`,
+  `HospitableConfigurationError`. `HospitableError` base unchanged.
+  **Breaking only for code that compared `err.name` to the old short
+  strings.** Use `instanceof` (recommended) or update the string.
+- **`ConnectFilter.where(field, …)` validates `field`** (`#48`) — field
+  names must match `/^[A-Za-z_][\w.]*$/`. Rejects newlines, ANSI
+  escapes, brackets, ampersands — blocking a log-injection path where
+  a hostile `field` value flowed into `ConfigurationError.message`. Same
+  guard applies to `sortAsc`, `sortDesc`, and `select`.
+- **`ConnectFilter.where` rejects commas in multi-value operators**
+  (`#52`) — `is`/`not`/`between` values containing a literal comma
+  previously produced ambiguous `field[is]=a,b` serialization. Now
+  throw `ConfigurationError` up front so callers can split or
+  normalize explicitly.
+- **Connect `*ListParams` no longer accept `string[]` at the index
+  signature** (`#49`) — tightening `ReservationListParams`,
+  `ReviewListParams`, `TransactionListParams`, `PayoutListParams`, and
+  `ResolutionListParams`. Stops a compile-time path where
+  `params.page = ['oops']` was accepted via the open index, then silently
+  produced NaN in `paginateConnect`.
+- **`TokenManager` no longer force-refreshes caller-supplied tokens
+  after 60s** (`#54`) — the default TTL is now 3600 seconds.
+
+### 🔒 Security
+
+- **Webhook signature verification** (`#43`) — see Added above. Before
+  this release, consumers were relying on the payload type guards
+  (`isConnectWebhookAction`, `isConnectWebhookFamily`) for structural
+  narrowing only, with no cryptographic authentication. Production
+  integrations must call `verifyWebhookSignature` before trusting the
+  body.
+- **Examples no longer log guest PII** (`#47`) — every sample script
+  under `examples/` now masks guest names / emails per AGENTS.md
+  §Safety. Copy-paste patterns are now PII-safe by default.
+- **`ConnectFilter` log-injection guard** (`#48`) — see Fixed above.
+
+### 🧪 Tests
+
+- **Connect AGENTS.md TDD triple** (`#44`) — every endpoint across the
+  10 Connect resources now has success, failure, and rate-limit tests.
+  Closes a gap where 10 of the 14 new Connect suites were success-only.
+- **Exponential-backoff growth assertion** (`#51`) — new test verifies
+  that `withRetry` delay grows geometrically across attempts, closing a
+  gap where a linear-backoff regression would have passed.
+- **Realistic webhook payload fixtures** (`#53`) — per-family payloads
+  replace the empty `{} as T['data']` casts. Type-guard narrowing is
+  now exercised through real field access, not incidentally.
+- **URL-keyed mocks in 401-refresh test** (`#55`) — `client.test.ts`
+  routes mock responses by URL pattern instead of call-count arithmetic.
+
 ## [0.7.0] — 2026-04-16
 
 Adds full **Hospitable Connect API** support alongside the existing

--- a/examples/get-in-house.ts
+++ b/examples/get-in-house.ts
@@ -11,10 +11,9 @@ const propertyIds = properties.map((p) => p.id)
 const inHouse = await client.reservations.getInHouse(propertyIds)
 console.log(`Guests currently in-house: ${inHouse.length}`)
 for (const r of inHouse) {
-  const guestName = r.guest
-    ? `${r.guest.firstName} ${r.guest.lastName}`
-    : 'unknown'
+  // AGENTS.md §Safety: no guest names in logs. The reservation `code` is
+  // unique and opaque enough to identify the row in ops dashboards.
   console.log(
-    `  ${guestName.padEnd(30)}  ${r.arrivalDate.slice(0, 10)} → ${r.departureDate.slice(0, 10)}  ${r.code}`,
+    `  code=${r.code.padEnd(10)}  ${r.arrivalDate.slice(0, 10)} → ${r.departureDate.slice(0, 10)}`,
   )
 }

--- a/examples/list-inquiries.ts
+++ b/examples/list-inquiries.ts
@@ -10,14 +10,16 @@ const filter = new InquiryFilter()
   .include('guest', 'properties')
   .perPage(25)
 
+// AGENTS.md §Safety forbids logging guest PII (names, emails). The outbound
+// message template still uses the real first name because it's being sent to
+// the guest — the log line below masks it so the PII never hits stdout.
 let count = 0
 for await (const inquiry of client.inquiries.iter(filter.toParams())) {
   count++
-  const guestName = `${inquiry.guest.firstName} ${inquiry.guest.lastName}`
   const stay = inquiry.arrivalDate
     ? `${inquiry.arrivalDate} → ${inquiry.departureDate}`
     : 'no dates'
-  console.log(`  ${inquiry.platform}  ${guestName}  ${stay}  (${inquiry.property?.name ?? 'n/a'})`)
+  console.log(`  ${inquiry.platform}  guest:<redacted>  ${stay}  (${inquiry.property?.name ?? 'n/a'})`)
 
   // Example: auto-reply to inquiries with no arrival date (still negotiating)
   if (!inquiry.arrivalDate) {

--- a/examples/reviews-with-includes.ts
+++ b/examples/reviews-with-includes.ts
@@ -26,7 +26,9 @@ for (const property of properties) {
   console.log(`Reviewed: ${review.reviewedAt}`)
 
   if (review.guest) {
-    console.log(`Guest:    ${review.guest.firstName} ${review.guest.lastName} (${review.guest.language})`)
+    // AGENTS.md §Safety: guest names are PII — log only the non-identifying
+    // locale so copy-pasters don't ship this pattern into production.
+    console.log(`Guest:    <redacted> (${review.guest.language})`)
   }
   if (review.reservation) {
     console.log(

--- a/examples/upcoming-reservations.ts
+++ b/examples/upcoming-reservations.ts
@@ -8,5 +8,9 @@ const propertyIds = properties.map((p) => p.id)
 const upcoming = await client.reservations.getUpcoming(propertyIds)
 console.log(`Upcoming reservations: ${upcoming.meta.total}`)
 for (const r of upcoming.data) {
-  console.log(`  ${r.arrivalDate} → ${r.departureDate}  guest: ${r.guest?.firstName ?? 'unknown'}`)
+  // AGENTS.md §Safety forbids logging guest PII. Use the reservation code
+  // (opaque to the guest) as the human-visible row identifier instead of
+  // `r.guest.firstName`. If you're debugging guest-specific logic, pipe
+  // through the SDK's `sanitize()` util rather than unmasking here.
+  console.log(`  ${r.arrivalDate} → ${r.departureDate}  code: ${r.code}`)
 }

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -126,42 +126,51 @@ describe('HospitableClient', () => {
   })
 
   it('a 401 from the API triggers token refresh and retries the request', async () => {
-    // When token+refreshToken+clientId+clientSecret are all provided, TokenManager
-    // treats the initial token as needing immediate refresh (expiresAt = now+60s,
-    // needsRefresh = now >= now). So the actual call order is:
-    //   call 1: /oauth/token (pre-call refresh)
-    //   call 2: API request → 401
-    //   call 3: /oauth/token (onUnauthorized refresh)
-    //   call 4: API retry → 200
-    let callCount = 0
-    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
-      callCount++
-      if (url.includes('/oauth/token')) {
-        // Token refresh calls always succeed
-        return Promise.resolve({
-          ok: true, status: 200,
-          headers: new Headers(),
-          json: async () => ({ access_token: 'new-token', expires_in: 3600, token_type: 'Bearer' }),
-          text: async () => '',
-        })
-      }
-      // First API call → 401; subsequent API calls → 200
-      const apiCallNumber = callCount - (callCount > 2 ? 2 : 1)
-      if (apiCallNumber === 1) {
-        return Promise.resolve({
-          ok: false, status: 401,
-          headers: new Headers(),
-          json: async () => ({ message: 'Unauthorized' }),
-          text: async () => 'Unauthorized',
-        })
-      }
-      return Promise.resolve({
-        ok: true, status: 200,
-        headers: new Headers({ 'Content-Type': 'application/json' }),
-        json: async () => ({ data: [], meta: { currentPage: 1, lastPage: 1, perPage: 10, total: 0 }, links: { first: null, last: null, prev: null, next: null } }),
-        text: async () => '',
-      })
-    }))
+    // URL-keyed routing (issue #55) — decouples test expectations from call
+    // ordering. Prior implementation counted calls and did conditional
+    // arithmetic to distinguish token vs. API paths, which silently broke
+    // when the refresh cadence changed. Route by URL pattern instead.
+    const okPropsResponse = () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: async () => ({
+        data: [],
+        meta: { currentPage: 1, lastPage: 1, perPage: 10, total: 0 },
+        links: { first: null, last: null, prev: null, next: null },
+      }),
+      text: async () => '',
+    })
+    const tokenRefreshResponse = () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => ({ access_token: 'new-token', expires_in: 3600, token_type: 'Bearer' }),
+      text: async () => '',
+    })
+    const unauthorizedResponse = () => ({
+      ok: false,
+      status: 401,
+      headers: new Headers(),
+      json: async () => ({ message: 'Unauthorized' }),
+      text: async () => 'Unauthorized',
+    })
+
+    // First properties call → 401 to trigger the refresh/retry cycle.
+    // All subsequent properties calls → 200.
+    const propsCall = vi.fn()
+      .mockImplementationOnce(unauthorizedResponse)
+      .mockImplementation(okPropsResponse)
+    const tokenCall = vi.fn().mockImplementation(tokenRefreshResponse)
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/oauth/token')) return Promise.resolve(tokenCall())
+        if (url.includes('/properties')) return Promise.resolve(propsCall())
+        throw new Error(`unexpected fetch URL: ${url}`)
+      }),
+    )
 
     const client = new HospitableClient({
       token: 'old-token',
@@ -172,7 +181,10 @@ describe('HospitableClient', () => {
 
     const result = await client.properties.list()
     expect(result.data).toEqual([])
-    // 1 pre-call token refresh + 1 API call (401) + 1 onUnauthorized token refresh + 1 API retry
-    expect(callCount).toBe(4)
+    // Route-level expectations — not order-dependent:
+    // - 2 properties requests (first 401, then 200 retry)
+    // - 1 token refresh triggered by onUnauthorized
+    expect(propsCall).toHaveBeenCalledTimes(2)
+    expect(tokenCall).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/__tests__/connect/auth-codes.test.ts
+++ b/src/__tests__/connect/auth-codes.test.ts
@@ -3,6 +3,12 @@ import { AuthCodesResource } from '../../connect/resources/auth-codes'
 import type { HttpClient } from '../../http/client'
 import type { AuthCode } from '../../connect/models'
 import { makeHttpClient } from '../helpers'
+import {
+  AuthenticationError,
+  NotFoundError,
+  RateLimitError,
+  ValidationError,
+} from '../../errors'
 
 describe('AuthCodesResource', () => {
   let http: HttpClient
@@ -34,6 +40,37 @@ describe('AuthCodesResource', () => {
     expect(http.post).toHaveBeenCalledWith('/auth-codes', {
       customerId: 'cust-1',
       redirectUrl: 'https://app.example.com/cb',
+    })
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('create() propagates ValidationError on 422 (bad customerId)', async () => {
+      vi.mocked(http.post).mockRejectedValue(
+        new ValidationError('Invalid customer', { customerId: ['must be a UUID'] }),
+      )
+      await expect(resource.create({ customerId: 'not-a-uuid' })).rejects.toBeInstanceOf(
+        ValidationError,
+      )
+    })
+
+    it('create() propagates NotFoundError on 404', async () => {
+      vi.mocked(http.post).mockRejectedValue(new NotFoundError('customer not found'))
+      await expect(resource.create({ customerId: 'ghost' })).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('create() propagates AuthenticationError on 401', async () => {
+      vi.mocked(http.post).mockRejectedValue(new AuthenticationError('token expired'))
+      await expect(resource.create({ customerId: 'cust-1' })).rejects.toBeInstanceOf(
+        AuthenticationError,
+      )
+    })
+
+    it('create() propagates RateLimitError on 429 with retryAfter preserved', async () => {
+      vi.mocked(http.post).mockRejectedValue(new RateLimitError(7))
+      await expect(resource.create({ customerId: 'cust-1' })).rejects.toMatchObject({
+        statusCode: 429,
+        retryAfter: 7,
+      })
     })
   })
 })

--- a/src/__tests__/connect/channels.test.ts
+++ b/src/__tests__/connect/channels.test.ts
@@ -3,6 +3,7 @@ import { ChannelsResource } from '../../connect/resources/channels'
 import type { HttpClient } from '../../http/client'
 import type { Channel, Listing } from '../../connect/models'
 import { makeHttpClient } from '../helpers'
+import { NotFoundError, RateLimitError, AuthenticationError } from '../../errors'
 
 const channel: Channel = {
   id: 'ch-1',
@@ -59,5 +60,57 @@ describe('ChannelsResource', () => {
     const result = await resource.getListing('ch-1', 'lst-1')
     expect(http.get).toHaveBeenCalledWith('/channels/ch-1/listings/lst-1')
     expect(result).toEqual(listing)
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('list() propagates AuthenticationError on 401', async () => {
+      vi.mocked(http.get).mockRejectedValue(new AuthenticationError('no creds'))
+      await expect(resource.list('cust-1')).rejects.toBeInstanceOf(AuthenticationError)
+    })
+
+    it('list() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(3))
+      await expect(resource.list('cust-1')).rejects.toMatchObject({ statusCode: 429, retryAfter: 3 })
+    })
+
+    it('get() propagates NotFoundError for unknown channel', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('channel not found'))
+      await expect(resource.get('cust-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('get() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(5))
+      await expect(resource.get('cust-1', 'ch-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('delete() propagates NotFoundError when channel missing', async () => {
+      vi.mocked(http.delete).mockRejectedValue(new NotFoundError('channel not found'))
+      await expect(resource.delete('cust-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('delete() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.delete).mockRejectedValue(new RateLimitError(10))
+      await expect(resource.delete('cust-1', 'ch-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('listListings() propagates NotFoundError when channel missing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('channel not found'))
+      await expect(resource.listListings('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('listListings() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(2))
+      await expect(resource.listListings('ch-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('getListing() propagates NotFoundError for unknown listing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('listing not found'))
+      await expect(resource.getListing('ch-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('getListing() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(4))
+      await expect(resource.getListing('ch-1', 'lst-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
   })
 })

--- a/src/__tests__/connect/client.test.ts
+++ b/src/__tests__/connect/client.test.ts
@@ -82,4 +82,98 @@ describe('HospitableConnectClient', () => {
       globalThis.fetch = prev
     }
   })
+
+  describe('onTokenExpired (issue #42)', () => {
+    it('retries with a freshly-minted token when a 401 triggers onTokenExpired', async () => {
+      const onTokenExpired = vi.fn().mockResolvedValue('fresh-token')
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ message: 'expired' }), {
+            status: 401,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ data: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+
+      const prev = globalThis.fetch
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+      try {
+        const client = new HospitableConnectClient({
+          token: 'stale-token',
+          onTokenExpired,
+        })
+        await client.channels.list('cust-1')
+
+        expect(onTokenExpired).toHaveBeenCalledOnce()
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+
+        const firstCallHeaders = (fetchMock.mock.calls[0]![1] as RequestInit).headers as Record<string, string>
+        const retryCallHeaders = (fetchMock.mock.calls[1]![1] as RequestInit).headers as Record<string, string>
+        expect(firstCallHeaders.Authorization).toBe('Bearer stale-token')
+        expect(retryCallHeaders.Authorization).toBe('Bearer fresh-token')
+      } finally {
+        globalThis.fetch = prev
+      }
+    })
+
+    it('persists the refreshed token across subsequent requests', async () => {
+      const onTokenExpired = vi.fn().mockResolvedValue('fresh-token')
+      const okResponse = () =>
+        new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ message: 'expired' }), {
+            status: 401,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+        .mockResolvedValueOnce(okResponse())
+        .mockResolvedValueOnce(okResponse())
+
+      const prev = globalThis.fetch
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+      try {
+        const client = new HospitableConnectClient({
+          token: 'stale-token',
+          onTokenExpired,
+        })
+        await client.channels.list('cust-1')
+        await client.channels.list('cust-2')
+
+        expect(onTokenExpired).toHaveBeenCalledOnce()
+        const secondRequestHeaders = (fetchMock.mock.calls[2]![1] as RequestInit).headers as Record<string, string>
+        expect(secondRequestHeaders.Authorization).toBe('Bearer fresh-token')
+      } finally {
+        globalThis.fetch = prev
+      }
+    })
+
+    it('leaves 401 as terminal when onTokenExpired is not supplied', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'expired' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      const prev = globalThis.fetch
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+      try {
+        const client = new HospitableConnectClient({ token: 'stale-token' })
+        await expect(client.channels.list('cust-1')).rejects.toThrow()
+        expect(fetchMock).toHaveBeenCalledOnce()
+      } finally {
+        globalThis.fetch = prev
+      }
+    })
+  })
 })

--- a/src/__tests__/connect/customers.test.ts
+++ b/src/__tests__/connect/customers.test.ts
@@ -3,6 +3,7 @@ import { CustomersResource } from '../../connect/resources/customers'
 import type { HttpClient } from '../../http/client'
 import type { ConnectPaginatedResponse, Customer } from '../../connect/models'
 import { makeHttpClient } from '../helpers'
+import { NotFoundError, RateLimitError, ValidationError } from '../../errors'
 
 const customer: Customer = {
   id: 'cust-1',
@@ -78,5 +79,65 @@ describe('CustomersResource', () => {
 
     expect(out).toEqual([customer, c2])
     expect(http.get).toHaveBeenCalledTimes(2)
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('list() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(3))
+      await expect(resource.list()).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('list() propagates server failures', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('endpoint missing'))
+      await expect(resource.list()).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('create() propagates ValidationError on duplicate id / bad payload', async () => {
+      vi.mocked(http.post).mockRejectedValue(
+        new ValidationError('Duplicate id', { id: ['already exists'] }),
+      )
+      await expect(
+        resource.create({
+          id: 'cust-1',
+          email: 'x@x.com',
+          name: 'X',
+          phone: '+1',
+          timezone: 'UTC',
+        }),
+      ).rejects.toBeInstanceOf(ValidationError)
+    })
+
+    it('create() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.post).mockRejectedValue(new RateLimitError(5))
+      await expect(
+        resource.create({
+          id: 'cust-1',
+          email: 'x@x.com',
+          name: 'X',
+          phone: '+1',
+          timezone: 'UTC',
+        }),
+      ).rejects.toMatchObject({ retryAfter: 5 })
+    })
+
+    it('get() propagates NotFoundError for unknown customer', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('customer not found'))
+      await expect(resource.get('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('get() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(2))
+      await expect(resource.get('cust-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('delete() propagates NotFoundError for unknown customer', async () => {
+      vi.mocked(http.delete).mockRejectedValue(new NotFoundError('customer not found'))
+      await expect(resource.delete('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('delete() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.delete).mockRejectedValue(new RateLimitError(8))
+      await expect(resource.delete('cust-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
   })
 })

--- a/src/__tests__/connect/filter.test.ts
+++ b/src/__tests__/connect/filter.test.ts
@@ -104,4 +104,82 @@ describe('ConnectFilter', () => {
     expect(branchB.toParams().per_page).toBe('20')
     expect(base.toParams()).not.toHaveProperty('per_page')
   })
+
+  describe('field-name validation (issue #48)', () => {
+    it.each([
+      ['newline', 'status\nadmin'],
+      ['ansi escape', 'status\u001b[31m'],
+      ['bracket', 'status]foo['],
+      ['ampersand', 'status&admin=1'],
+      ['leading digit', '1status'],
+      ['empty string', ''],
+      ['whitespace', 'status field'],
+      ['semicolon', 'status;drop'],
+    ])('rejects %s in where() field', (_label, field) => {
+      expect(() => new ConnectFilter().where(field, 'is', ['x'])).toThrow(ConfigurationError)
+    })
+
+    it('does not echo the offending field in the error message', () => {
+      // Log-injection guard: if the field had an ANSI escape or newline,
+      // we must not flow it through ConfigurationError.message into logs.
+      const nasty = 'nasty\u001b[31m\nINJECTED'
+      try {
+        new ConnectFilter().where(nasty, 'is', ['x'])
+        throw new Error('expected ConfigurationError')
+      } catch (err) {
+        expect(err).toBeInstanceOf(ConfigurationError)
+        expect((err as Error).message).not.toContain('INJECTED')
+        expect((err as Error).message).not.toContain('\u001b')
+      }
+    })
+
+    it('accepts valid field names including nested paths', () => {
+      expect(() =>
+        new ConnectFilter().where('financials.host.amount', 'gte', 100),
+      ).not.toThrow()
+      expect(() => new ConnectFilter().where('_select', 'is', ['a'])).not.toThrow()
+      expect(() => new ConnectFilter().where('status', 'is', ['x'])).not.toThrow()
+    })
+
+    it('rejects invalid field names in sortAsc / sortDesc / select', () => {
+      expect(() => new ConnectFilter().sortAsc('bad field')).toThrow(ConfigurationError)
+      expect(() => new ConnectFilter().sortDesc('1badstart')).toThrow(ConfigurationError)
+      expect(() => new ConnectFilter().select('ok', 'bad]field')).toThrow(ConfigurationError)
+    })
+  })
+
+  describe('special-character handling in values (issue #52)', () => {
+    it('rejects comma-containing string values for is/not', () => {
+      // "San Francisco, CA" would silently split into ['San Francisco', ' CA']
+      // when the API parses the multi-value list — reject up front.
+      expect(() =>
+        new ConnectFilter().where('city', 'is', ['San Francisco, CA', 'Austin']),
+      ).toThrow(ConfigurationError)
+      expect(() =>
+        new ConnectFilter().where('status', 'not', ['accept,decline']),
+      ).toThrow(ConfigurationError)
+    })
+
+    it('rejects comma-containing values for between', () => {
+      expect(() =>
+        new ConnectFilter().where('range', 'between', ['100,200', '500']),
+      ).toThrow(ConfigurationError)
+    })
+
+    it('accepts ampersand and percent-sign values (URL-encoded by URLSearchParams)', () => {
+      // `&` and `%` in values are safe — URLSearchParams.set() encodes them.
+      // Only commas are structural (the multi-value delimiter).
+      const params = new ConnectFilter()
+        .where('note', 'is', ['100% off & free'])
+        .toParams()
+      expect(params['note[is]']).toBe('100% off & free')
+    })
+
+    it('allows the comma-safe path — single-value ops can contain commas in the value string', () => {
+      // `before`/`after`/etc. take exactly one value; there is no splitting,
+      // so commas in the single value are preserved.
+      const params = new ConnectFilter().where('note', 'gte', 'before,comma').toParams()
+      expect(params['note[gte]']).toBe('before,comma')
+    })
+  })
 })

--- a/src/__tests__/connect/listings.test.ts
+++ b/src/__tests__/connect/listings.test.ts
@@ -7,7 +7,12 @@ import type {
   Listing,
   ListingImage,
 } from '../../connect/models'
-import { ConfigurationError } from '../../errors'
+import {
+  ConfigurationError,
+  NotFoundError,
+  RateLimitError,
+  ValidationError,
+} from '../../errors'
 import { makeHttpClient } from '../helpers'
 
 const listing = { id: 'lst-1' } as unknown as Listing
@@ -90,5 +95,67 @@ describe('ListingsResource', () => {
     const collected: Listing[] = []
     for await (const l of resource.iter('cust-1')) collected.push(l)
     expect(collected).toEqual([listing])
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('list() propagates NotFoundError when customer missing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('customer not found'))
+      await expect(resource.list('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('list() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(5))
+      await expect(resource.list('cust-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('get() propagates NotFoundError for unknown listing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('listing not found'))
+      await expect(resource.get('cust-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('get() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(2))
+      await expect(resource.get('cust-1', 'lst-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('getImages() propagates NotFoundError for unknown listing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('listing not found'))
+      await expect(resource.getImages('cust-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('getImages() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(3))
+      await expect(resource.getImages('cust-1', 'lst-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('getCalendar() propagates NotFoundError for unknown listing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('listing not found'))
+      await expect(
+        resource.getCalendar('ghost', { startDate: '2026-01-01', endDate: '2026-01-31' }),
+      ).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('getCalendar() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(4))
+      await expect(
+        resource.getCalendar('lst-1', { startDate: '2026-01-01', endDate: '2026-01-31' }),
+      ).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('updateCalendar() propagates ValidationError on bad day payload', async () => {
+      vi.mocked(http.put).mockRejectedValue(
+        new ValidationError('Invalid payload', { 'days.0.date': ['must be YYYY-MM-DD'] }),
+      )
+      await expect(
+        resource.updateCalendar('lst-1', [{ date: 'bogus' } as unknown as never]),
+      ).rejects.toBeInstanceOf(ValidationError)
+    })
+
+    it('updateCalendar() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.put).mockRejectedValue(new RateLimitError(6))
+      await expect(
+        resource.updateCalendar('lst-1', [{ date: '2026-01-01' }]),
+      ).rejects.toBeInstanceOf(RateLimitError)
+    })
   })
 })

--- a/src/__tests__/connect/messaging.test.ts
+++ b/src/__tests__/connect/messaging.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MessagingResource } from '../../connect/resources/messaging'
 import type { HttpClient } from '../../http/client'
 import type { ConnectPaginatedResponse, MessageTemplate } from '../../connect/models'
-import { ConfigurationError } from '../../errors'
+import {
+  ConfigurationError,
+  NotFoundError,
+  RateLimitError,
+  ValidationError,
+} from '../../errors'
 import { makeHttpClient } from '../helpers'
 
 const template: MessageTemplate = {
@@ -69,5 +74,52 @@ describe('MessagingResource', () => {
     const out: typeof template[] = []
     for await (const t of resource.iterTemplates()) out.push(t)
     expect(out).toEqual([template])
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('listTemplates() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(3))
+      await expect(resource.listTemplates()).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('listTemplates() propagates NotFoundError on 404', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('route not found'))
+      await expect(resource.listTemplates()).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('getTemplate() propagates NotFoundError for missing template', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('template not found'))
+      await expect(resource.getTemplate('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('getTemplate() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(4))
+      await expect(resource.getTemplate('tpl-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('send() propagates ValidationError on 422 (placeholder mismatch)', async () => {
+      vi.mocked(http.post).mockRejectedValue(
+        new ValidationError('Placeholder mismatch', {
+          placeholders: ['missing required: name'],
+        }),
+      )
+      await expect(
+        resource.send('res-1', { templateId: 'tpl-1', placeholders: {} }),
+      ).rejects.toBeInstanceOf(ValidationError)
+    })
+
+    it('send() propagates NotFoundError on 404 (unknown reservation)', async () => {
+      vi.mocked(http.post).mockRejectedValue(new NotFoundError('reservation not found'))
+      await expect(
+        resource.send('ghost', { templateId: 'tpl-1', placeholders: { name: 'x' } }),
+      ).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('send() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.post).mockRejectedValue(new RateLimitError(5))
+      await expect(
+        resource.send('res-1', { templateId: 'tpl-1', placeholders: { name: 'x' } }),
+      ).rejects.toMatchObject({ retryAfter: 5 })
+    })
   })
 })

--- a/src/__tests__/connect/payouts.test.ts
+++ b/src/__tests__/connect/payouts.test.ts
@@ -3,6 +3,7 @@ import { PayoutsResource } from '../../connect/resources/payouts'
 import type { HttpClient } from '../../http/client'
 import type { ConnectPaginatedResponse, Payout } from '../../connect/models'
 import { makeHttpClient } from '../helpers'
+import { ForbiddenError, NotFoundError, RateLimitError } from '../../errors'
 
 const payout = { id: 'po-1' } as unknown as Payout
 
@@ -41,5 +42,32 @@ describe('PayoutsResource', () => {
     const out: Payout[] = []
     for await (const p of resource.iter('ch-1')) out.push(p)
     expect(out).toEqual([payout])
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('list() propagates NotFoundError when channel missing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('channel not found'))
+      await expect(resource.list('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('list() propagates ForbiddenError on missing payouts scope (403)', async () => {
+      vi.mocked(http.get).mockRejectedValue(new ForbiddenError('missing payouts scope'))
+      await expect(resource.list('ch-1')).rejects.toBeInstanceOf(ForbiddenError)
+    })
+
+    it('list() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(3))
+      await expect(resource.list('ch-1')).rejects.toMatchObject({ retryAfter: 3 })
+    })
+
+    it('get() propagates NotFoundError for unknown payout', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('payout not found'))
+      await expect(resource.get('ch-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('get() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(5))
+      await expect(resource.get('ch-1', 'po-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
   })
 })

--- a/src/__tests__/connect/reservations.test.ts
+++ b/src/__tests__/connect/reservations.test.ts
@@ -3,6 +3,7 @@ import { ReservationsResource } from '../../connect/resources/reservations'
 import type { HttpClient } from '../../http/client'
 import type { ConnectPaginatedResponse, Reservation } from '../../connect/models'
 import { makeHttpClient } from '../helpers'
+import { NotFoundError, RateLimitError } from '../../errors'
 
 const reservation = { id: 'res-1' } as unknown as Reservation
 
@@ -82,5 +83,47 @@ describe('ReservationsResource', () => {
         'status[not]': 'deny,cancelled',
       }),
     )
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('listByListing() propagates NotFoundError when listing missing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('listing not found'))
+      await expect(resource.listByListing('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('listByListing() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(3))
+      await expect(resource.listByListing('lst-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('getByListing() propagates NotFoundError for stale reservation id', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('reservation not found'))
+      await expect(resource.getByListing('lst-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('getByListing() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(7))
+      await expect(resource.getByListing('lst-1', 'res-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('listByCustomer() propagates NotFoundError when customer missing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('customer not found'))
+      await expect(resource.listByCustomer('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('listByCustomer() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(2))
+      await expect(resource.listByCustomer('cust-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('getByCustomer() propagates NotFoundError for unknown reservation', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('reservation not found'))
+      await expect(resource.getByCustomer('cust-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('getByCustomer() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(6))
+      await expect(resource.getByCustomer('cust-1', 'res-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
   })
 })

--- a/src/__tests__/connect/resolutions.test.ts
+++ b/src/__tests__/connect/resolutions.test.ts
@@ -3,6 +3,7 @@ import { ResolutionsResource } from '../../connect/resources/resolutions'
 import type { HttpClient } from '../../http/client'
 import type { ConnectPaginatedResponse, Resolution } from '../../connect/models'
 import { makeHttpClient } from '../helpers'
+import { NotFoundError, RateLimitError } from '../../errors'
 
 const resolution = { id: 'rz-1' } as unknown as Resolution
 
@@ -34,5 +35,37 @@ describe('ResolutionsResource', () => {
     const out: Resolution[] = []
     for await (const r of resource.iter('ch-1')) out.push(r)
     expect(out).toEqual([resolution])
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('list() propagates NotFoundError when channel missing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('channel not found'))
+      await expect(resource.list('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('list() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(4))
+      await expect(resource.list('ch-1')).rejects.toMatchObject({ retryAfter: 4 })
+    })
+
+    it('iter() propagates NotFoundError on the first page', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('channel not found'))
+      const run = async () => {
+        for await (const _ of resource.iter('ghost')) {
+          /* never reached */
+        }
+      }
+      await expect(run()).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('iter() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(8))
+      const run = async () => {
+        for await (const _ of resource.iter('ch-1')) {
+          /* never reached */
+        }
+      }
+      await expect(run()).rejects.toBeInstanceOf(RateLimitError)
+    })
   })
 })

--- a/src/__tests__/connect/reviews.test.ts
+++ b/src/__tests__/connect/reviews.test.ts
@@ -3,6 +3,7 @@ import { ReviewsResource } from '../../connect/resources/reviews'
 import type { HttpClient } from '../../http/client'
 import type { ConnectPaginatedResponse, Review } from '../../connect/models'
 import { makeHttpClient } from '../helpers'
+import { NotFoundError, RateLimitError } from '../../errors'
 
 const review = { id: 'rev-1' } as unknown as Review
 
@@ -34,5 +35,37 @@ describe('ReviewsResource', () => {
     const out: Review[] = []
     for await (const r of resource.iter('ch-1')) out.push(r)
     expect(out).toEqual([review])
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('list() propagates NotFoundError when channel missing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('channel not found'))
+      await expect(resource.list('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('list() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(4))
+      await expect(resource.list('ch-1')).rejects.toMatchObject({ retryAfter: 4 })
+    })
+
+    it('iter() propagates NotFoundError on the first page', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('channel not found'))
+      const run = async () => {
+        for await (const _ of resource.iter('ghost')) {
+          /* never reached */
+        }
+      }
+      await expect(run()).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('iter() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(6))
+      const run = async () => {
+        for await (const _ of resource.iter('ch-1')) {
+          /* never reached */
+        }
+      }
+      await expect(run()).rejects.toBeInstanceOf(RateLimitError)
+    })
   })
 })

--- a/src/__tests__/connect/transactions.test.ts
+++ b/src/__tests__/connect/transactions.test.ts
@@ -3,6 +3,12 @@ import { TransactionsResource } from '../../connect/resources/transactions'
 import type { HttpClient } from '../../http/client'
 import type { ConnectPaginatedResponse, Transaction } from '../../connect/models'
 import { makeHttpClient } from '../helpers'
+import {
+  AuthenticationError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitError,
+} from '../../errors'
 
 const tx = { id: 'tx-1' } as unknown as Transaction
 
@@ -41,5 +47,39 @@ describe('TransactionsResource', () => {
     const out: Transaction[] = []
     for await (const t of resource.iter('ch-1')) out.push(t)
     expect(out).toEqual([tx])
+  })
+
+  describe('failure and rate-limit (AGENTS.md triple)', () => {
+    it('list() propagates NotFoundError when channel missing', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('channel not found'))
+      await expect(resource.list('ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('list() propagates ForbiddenError on missing payments scope (403)', async () => {
+      // Transactions require an additional OAuth scope granted after the
+      // 2024-01-12 auth-code update. Pre-update customers see 403 here.
+      vi.mocked(http.get).mockRejectedValue(new ForbiddenError('missing payments scope'))
+      await expect(resource.list('ch-1')).rejects.toBeInstanceOf(ForbiddenError)
+    })
+
+    it('list() — ForbiddenError is instance of AuthenticationError (issue #45)', async () => {
+      vi.mocked(http.get).mockRejectedValue(new ForbiddenError('missing payments scope'))
+      await expect(resource.list('ch-1')).rejects.toBeInstanceOf(AuthenticationError)
+    })
+
+    it('list() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(3))
+      await expect(resource.list('ch-1')).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it('get() propagates NotFoundError for stale transaction id', async () => {
+      vi.mocked(http.get).mockRejectedValue(new NotFoundError('transaction not found'))
+      await expect(resource.get('ch-1', 'ghost')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('get() propagates RateLimitError on 429', async () => {
+      vi.mocked(http.get).mockRejectedValue(new RateLimitError(9))
+      await expect(resource.get('ch-1', 'tx-1')).rejects.toMatchObject({ retryAfter: 9 })
+    })
   })
 })

--- a/src/__tests__/connect/webhook-verify.test.ts
+++ b/src/__tests__/connect/webhook-verify.test.ts
@@ -10,148 +10,151 @@ function sign(body: string, secret: string, algo: 'sha256' | 'sha1' = 'sha256'):
 }
 
 describe('verifyWebhookSignature', () => {
-  it('returns true for a correctly-signed body', () => {
+  it('returns true for a correctly-signed body', async () => {
     const signature = sign(BODY, SECRET)
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: signature,
         secret: SECRET,
       }),
-    ).toBe(true)
+    ).resolves.toBe(true)
   })
 
-  it('returns false when the signature is tampered by a single byte', () => {
+  it('returns false when the signature is tampered by a single byte', async () => {
     const signature = sign(BODY, SECRET)
     const tampered = signature.slice(0, -1) + (signature.endsWith('0') ? '1' : '0')
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: tampered,
         secret: SECRET,
       }),
-    ).toBe(false)
+    ).resolves.toBe(false)
   })
 
-  it('returns false when the body is tampered', () => {
+  it('returns false when the body is tampered', async () => {
     const signature = sign(BODY, SECRET)
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY + ' ',
         signatureHeader: signature,
         secret: SECRET,
       }),
-    ).toBe(false)
+    ).resolves.toBe(false)
   })
 
-  it('returns false when the secret is wrong', () => {
+  it('returns false when the secret is wrong', async () => {
     const signature = sign(BODY, SECRET)
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: signature,
         secret: 'wrong-secret',
       }),
-    ).toBe(false)
+    ).resolves.toBe(false)
   })
 
-  it('returns false on empty signatureHeader', () => {
-    expect(
+  it('returns false on empty signatureHeader', async () => {
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: '',
         secret: SECRET,
       }),
-    ).toBe(false)
+    ).resolves.toBe(false)
   })
 
-  it('returns false on empty secret', () => {
-    expect(
+  it('returns false on empty secret', async () => {
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: sign(BODY, SECRET),
         secret: '',
       }),
-    ).toBe(false)
+    ).resolves.toBe(false)
   })
 
-  it('strips an algo= prefix from the header (e.g. "sha256=abc…")', () => {
+  it('strips an algo= prefix from the header (e.g. "sha256=abc…")', async () => {
     const signature = sign(BODY, SECRET)
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: `sha256=${signature}`,
         secret: SECRET,
       }),
-    ).toBe(true)
+    ).resolves.toBe(true)
   })
 
-  it('supports Buffer rawBody', () => {
-    const buf = Buffer.from(BODY, 'utf8')
-    expect(
-      verifyWebhookSignature({
-        rawBody: buf,
-        signatureHeader: sign(BODY, SECRET),
-        secret: SECRET,
-      }),
-    ).toBe(true)
-  })
-
-  it('supports Uint8Array rawBody', () => {
+  it('supports Uint8Array rawBody', async () => {
     const arr = new TextEncoder().encode(BODY)
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: arr,
         signatureHeader: sign(BODY, SECRET),
         secret: SECRET,
       }),
-    ).toBe(true)
+    ).resolves.toBe(true)
   })
 
-  it('supports base64-encoded headers when encoding: "base64"', () => {
+  it('supports Buffer rawBody (Buffer extends Uint8Array)', async () => {
+    // Buffer is a Node subclass of Uint8Array; the SDK typechecks against
+    // Uint8Array only so Node's Buffer works at runtime without forcing a
+    // @types/node dependency on downstream consumers.
+    const buf = Buffer.from(BODY, 'utf8')
+    await expect(
+      verifyWebhookSignature({
+        rawBody: buf,
+        signatureHeader: sign(BODY, SECRET),
+        secret: SECRET,
+      }),
+    ).resolves.toBe(true)
+  })
+
+  it('supports base64-encoded headers when encoding: "base64"', async () => {
     const b64 = createHmac('sha256', SECRET).update(BODY).digest('base64')
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: b64,
         secret: SECRET,
         encoding: 'base64',
       }),
-    ).toBe(true)
+    ).resolves.toBe(true)
   })
 
-  it('supports sha1 for legacy providers', () => {
+  it('supports sha1 for legacy providers', async () => {
     const sig = sign(BODY, SECRET, 'sha1')
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: sig,
         secret: SECRET,
         algorithm: 'sha1',
       }),
-    ).toBe(true)
+    ).resolves.toBe(true)
   })
 
-  it('returns false when sha256 header is validated against sha1', () => {
+  it('returns false when sha256 header is validated against sha1', async () => {
     const sig = sign(BODY, SECRET, 'sha256')
-    expect(
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: sig,
         secret: SECRET,
         algorithm: 'sha1',
       }),
-    ).toBe(false)
+    ).resolves.toBe(false)
   })
 
-  it('returns false on malformed hex (length-mismatch rejection path)', () => {
-    expect(
+  it('returns false on malformed hex (length-mismatch rejection path)', async () => {
+    await expect(
       verifyWebhookSignature({
         rawBody: BODY,
         signatureHeader: 'not-hex',
         secret: SECRET,
       }),
-    ).toBe(false)
+    ).resolves.toBe(false)
   })
 
   describe('timestamped signing (anti-replay)', () => {
@@ -165,25 +168,25 @@ describe('verifyWebhookSignature', () => {
       vi.useRealTimers()
     })
 
-    it('accepts a payload signed as `${timestamp}.${body}` within tolerance', () => {
+    it('accepts a payload signed as `${timestamp}.${body}` within tolerance', async () => {
       const timestamp = String(NOW_SECONDS)
       const signedPayload = `${timestamp}.${BODY}`
       const signature = sign(signedPayload, SECRET)
-      expect(
+      await expect(
         verifyWebhookSignature({
           rawBody: BODY,
           signatureHeader: signature,
           secret: SECRET,
           timestamp,
         }),
-      ).toBe(true)
+      ).resolves.toBe(true)
     })
 
-    it('rejects a payload older than toleranceSeconds', () => {
+    it('rejects a payload older than toleranceSeconds', async () => {
       const timestamp = String(NOW_SECONDS - 600)
       const signedPayload = `${timestamp}.${BODY}`
       const signature = sign(signedPayload, SECRET)
-      expect(
+      await expect(
         verifyWebhookSignature({
           rawBody: BODY,
           signatureHeader: signature,
@@ -191,57 +194,52 @@ describe('verifyWebhookSignature', () => {
           timestamp,
           toleranceSeconds: 300,
         }),
-      ).toBe(false)
+      ).resolves.toBe(false)
     })
 
-    it('rejects a non-numeric timestamp', () => {
-      expect(
+    it('rejects a non-numeric timestamp', async () => {
+      await expect(
         verifyWebhookSignature({
           rawBody: BODY,
           signatureHeader: sign(BODY, SECRET),
           secret: SECRET,
           timestamp: 'not-a-number',
         }),
-      ).toBe(false)
+      ).resolves.toBe(false)
     })
 
-    it('uses default toleranceSeconds of 300 when unspecified', () => {
-      // 299 seconds old — inside default window
+    it('uses default toleranceSeconds of 300 when unspecified', async () => {
       const tsInside = String(NOW_SECONDS - 299)
       const sigInside = sign(`${tsInside}.${BODY}`, SECRET)
-      expect(
+      await expect(
         verifyWebhookSignature({
           rawBody: BODY,
           signatureHeader: sigInside,
           secret: SECRET,
           timestamp: tsInside,
         }),
-      ).toBe(true)
+      ).resolves.toBe(true)
 
-      // 301 seconds old — outside default window
       const tsOutside = String(NOW_SECONDS - 301)
       const sigOutside = sign(`${tsOutside}.${BODY}`, SECRET)
-      expect(
+      await expect(
         verifyWebhookSignature({
           rawBody: BODY,
           signatureHeader: sigOutside,
           secret: SECRET,
           timestamp: tsOutside,
         }),
-      ).toBe(false)
+      ).resolves.toBe(false)
     })
   })
 
-  it('never throws on mismatched input (DoS guard)', () => {
-    // A hostile sender could craft a body or header designed to crash the
-    // handler. Verify that verify() contains all failure modes and returns
-    // a clean boolean rather than bubbling an exception.
-    expect(() =>
+  it('never throws on mismatched input (DoS guard)', async () => {
+    await expect(
       verifyWebhookSignature({
         rawBody: '',
         signatureHeader: '!!@@@',
         secret: SECRET,
       }),
-    ).not.toThrow()
+    ).resolves.toBe(false)
   })
 })

--- a/src/__tests__/connect/webhook-verify.test.ts
+++ b/src/__tests__/connect/webhook-verify.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createHmac } from 'node:crypto'
+import { verifyWebhookSignature } from '../../connect/webhooks/verify'
+
+const SECRET = 'test-secret-do-not-use-in-prod'
+const BODY = JSON.stringify({ id: '01HW', action: 'reservation.created', data: {} })
+
+function sign(body: string, secret: string, algo: 'sha256' | 'sha1' = 'sha256'): string {
+  return createHmac(algo, secret).update(body).digest('hex')
+}
+
+describe('verifyWebhookSignature', () => {
+  it('returns true for a correctly-signed body', () => {
+    const signature = sign(BODY, SECRET)
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: signature,
+        secret: SECRET,
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false when the signature is tampered by a single byte', () => {
+    const signature = sign(BODY, SECRET)
+    const tampered = signature.slice(0, -1) + (signature.endsWith('0') ? '1' : '0')
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: tampered,
+        secret: SECRET,
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false when the body is tampered', () => {
+    const signature = sign(BODY, SECRET)
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY + ' ',
+        signatureHeader: signature,
+        secret: SECRET,
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false when the secret is wrong', () => {
+    const signature = sign(BODY, SECRET)
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: signature,
+        secret: 'wrong-secret',
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false on empty signatureHeader', () => {
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: '',
+        secret: SECRET,
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false on empty secret', () => {
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: sign(BODY, SECRET),
+        secret: '',
+      }),
+    ).toBe(false)
+  })
+
+  it('strips an algo= prefix from the header (e.g. "sha256=abc…")', () => {
+    const signature = sign(BODY, SECRET)
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: `sha256=${signature}`,
+        secret: SECRET,
+      }),
+    ).toBe(true)
+  })
+
+  it('supports Buffer rawBody', () => {
+    const buf = Buffer.from(BODY, 'utf8')
+    expect(
+      verifyWebhookSignature({
+        rawBody: buf,
+        signatureHeader: sign(BODY, SECRET),
+        secret: SECRET,
+      }),
+    ).toBe(true)
+  })
+
+  it('supports Uint8Array rawBody', () => {
+    const arr = new TextEncoder().encode(BODY)
+    expect(
+      verifyWebhookSignature({
+        rawBody: arr,
+        signatureHeader: sign(BODY, SECRET),
+        secret: SECRET,
+      }),
+    ).toBe(true)
+  })
+
+  it('supports base64-encoded headers when encoding: "base64"', () => {
+    const b64 = createHmac('sha256', SECRET).update(BODY).digest('base64')
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: b64,
+        secret: SECRET,
+        encoding: 'base64',
+      }),
+    ).toBe(true)
+  })
+
+  it('supports sha1 for legacy providers', () => {
+    const sig = sign(BODY, SECRET, 'sha1')
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: sig,
+        secret: SECRET,
+        algorithm: 'sha1',
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false when sha256 header is validated against sha1', () => {
+    const sig = sign(BODY, SECRET, 'sha256')
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: sig,
+        secret: SECRET,
+        algorithm: 'sha1',
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false on malformed hex (length-mismatch rejection path)', () => {
+    expect(
+      verifyWebhookSignature({
+        rawBody: BODY,
+        signatureHeader: 'not-hex',
+        secret: SECRET,
+      }),
+    ).toBe(false)
+  })
+
+  describe('timestamped signing (anti-replay)', () => {
+    const NOW_SECONDS = 1_700_000_000
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(NOW_SECONDS * 1000)
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('accepts a payload signed as `${timestamp}.${body}` within tolerance', () => {
+      const timestamp = String(NOW_SECONDS)
+      const signedPayload = `${timestamp}.${BODY}`
+      const signature = sign(signedPayload, SECRET)
+      expect(
+        verifyWebhookSignature({
+          rawBody: BODY,
+          signatureHeader: signature,
+          secret: SECRET,
+          timestamp,
+        }),
+      ).toBe(true)
+    })
+
+    it('rejects a payload older than toleranceSeconds', () => {
+      const timestamp = String(NOW_SECONDS - 600)
+      const signedPayload = `${timestamp}.${BODY}`
+      const signature = sign(signedPayload, SECRET)
+      expect(
+        verifyWebhookSignature({
+          rawBody: BODY,
+          signatureHeader: signature,
+          secret: SECRET,
+          timestamp,
+          toleranceSeconds: 300,
+        }),
+      ).toBe(false)
+    })
+
+    it('rejects a non-numeric timestamp', () => {
+      expect(
+        verifyWebhookSignature({
+          rawBody: BODY,
+          signatureHeader: sign(BODY, SECRET),
+          secret: SECRET,
+          timestamp: 'not-a-number',
+        }),
+      ).toBe(false)
+    })
+
+    it('uses default toleranceSeconds of 300 when unspecified', () => {
+      // 299 seconds old — inside default window
+      const tsInside = String(NOW_SECONDS - 299)
+      const sigInside = sign(`${tsInside}.${BODY}`, SECRET)
+      expect(
+        verifyWebhookSignature({
+          rawBody: BODY,
+          signatureHeader: sigInside,
+          secret: SECRET,
+          timestamp: tsInside,
+        }),
+      ).toBe(true)
+
+      // 301 seconds old — outside default window
+      const tsOutside = String(NOW_SECONDS - 301)
+      const sigOutside = sign(`${tsOutside}.${BODY}`, SECRET)
+      expect(
+        verifyWebhookSignature({
+          rawBody: BODY,
+          signatureHeader: sigOutside,
+          secret: SECRET,
+          timestamp: tsOutside,
+        }),
+      ).toBe(false)
+    })
+  })
+
+  it('never throws on mismatched input (DoS guard)', () => {
+    // A hostile sender could craft a body or header designed to crash the
+    // handler. Verify that verify() contains all failure modes and returns
+    // a clean boolean rather than bubbling an exception.
+    expect(() =>
+      verifyWebhookSignature({
+        rawBody: '',
+        signatureHeader: '!!@@@',
+        secret: SECRET,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/src/__tests__/connect/webhooks.test.ts
+++ b/src/__tests__/connect/webhooks.test.ts
@@ -2,9 +2,17 @@ import { describe, it, expect } from 'vitest'
 import {
   isConnectWebhookAction,
   isConnectWebhookFamily,
+  type ChannelWebhookPayload,
   type ConnectWebhookPayload,
+  type ListingWebhookPayload,
+  type PayoutWebhookPayload,
   type ReservationWebhookPayload,
+  type ReviewWebhookPayload,
+  type TransactionWebhookPayload,
 } from '../../connect/webhooks'
+import type { Channel } from '../../connect/models/channel'
+import type { Customer } from '../../connect/models/customer'
+import type { Financial } from '../../connect/models/shared'
 
 const reservationPayload: ReservationWebhookPayload = {
   id: '01H3',
@@ -50,5 +58,341 @@ describe('Connect webhook type guards', () => {
     expect(reservationPayload).toHaveProperty('action')
     expect(reservationPayload).toHaveProperty('version')
     expect(reservationPayload).toHaveProperty('data')
+  })
+})
+
+/* ------------ Realistic fixtures (issue #53) ------------
+ *
+ * The original tests above use `{} as T['data']` — the type guard branches
+ * "work" because branch coverage is incidentally hit, but the narrowed-type
+ * `data` field path is never meaningfully asserted. These tests build
+ * shape-accurate payloads per family and exercise field access on the
+ * narrowed type without any cast. A type-guard regression that removed a
+ * field from the narrowing would now fail to compile.
+ */
+
+const financial: Financial = {
+  amount: 25000,
+  formatted: '$250.00',
+  currency: 'USD',
+  label: null,
+}
+
+const channel: Channel = {
+  id: 'ch_01',
+  platform: 'airbnb',
+  platformId: 'abb_u_12345',
+  name: "Host's Airbnb",
+  picture: null,
+  location: 'San Francisco, CA',
+  description: null,
+  firstConnectedAt: '2026-01-01T00:00:00Z',
+  readyToMigrate: null,
+}
+
+const customer: Customer = {
+  id: 'cust_01',
+  email: 'partner@example.com',
+  name: 'Partner Inc',
+  phone: '+15555550100',
+  ipAddress: '192.0.2.1',
+  timezone: 'America/Los_Angeles',
+}
+
+describe('Connect webhook payloads — narrowed field access (issue #53)', () => {
+  it('channel.activated — data carries full Channel + Customer', () => {
+    const payload: ChannelWebhookPayload = {
+      id: '01HCHAN',
+      created: '2026-04-16T00:00:00Z',
+      action: 'channel.activated',
+      version: '2023-03-02',
+      data: { ...channel, customer },
+    }
+    const generic: ConnectWebhookPayload = payload
+    if (isConnectWebhookFamily(generic, 'channel')) {
+      // Narrowed access — no cast, no `any`.
+      expect(generic.data.platform).toBe('airbnb')
+      expect(generic.data.customer.email).toBe('partner@example.com')
+    } else {
+      expect.unreachable()
+    }
+  })
+
+  it('listing.created — narrows to Listing fields + customer', () => {
+    const payload: ListingWebhookPayload = {
+      id: '01HLIST',
+      created: '2026-04-16T00:00:00Z',
+      action: 'listing.created',
+      version: '2023-03-02',
+      data: {
+        id: 'lst_01',
+        platform: 'airbnb',
+        platformId: 'abb_l_99',
+        publicName: 'Downtown Loft',
+        privateName: 'SF-Loft-01',
+        summary: 'Cozy',
+        description: 'Cozy loft.',
+        roomType: 'entire_home',
+        propertyType: 'apartment',
+        picture: 'https://example.com/p.jpg',
+        address: {
+          street: '1 Market St',
+          zipcode: '94105',
+          city: 'San Francisco',
+          state: 'CA',
+          apt: '',
+          countryCode: 'US',
+          latitude: 37.79,
+          longitude: -122.4,
+        },
+        capacity: { max: 4, bedrooms: 1, beds: 1, bathrooms: 1 },
+        roomDetails: [],
+        bathrooms: 1,
+        bedrooms: 1,
+        available: 1,
+        channel,
+        channels: [channel],
+        fees: [],
+        amenities: ['wifi'],
+        'check-in': '15:00',
+        'check-out': '11:00',
+        details: {
+          spaceOverview: null,
+          guestAccess: null,
+          houseManual: null,
+          notes: null,
+          additionalRules: null,
+          neighborhoodDescription: null,
+          gettingAround: null,
+          wifiName: null,
+          wifiPassword: null,
+        },
+        houseRules: { petsAllowed: false, smokingAllowed: false, eventsAllowed: false },
+        customer,
+      },
+    }
+    const generic: ConnectWebhookPayload = payload
+    if (isConnectWebhookAction(generic, 'listing.created')) {
+      expect(generic.data.publicName).toBe('Downtown Loft')
+      expect(generic.data.address.city).toBe('San Francisco')
+      expect(generic.data.customer.id).toBe('cust_01')
+    } else {
+      expect.unreachable()
+    }
+  })
+
+  it('reservation.created — narrows to Reservation fields + listing/channel/customer', () => {
+    const payload: ReservationWebhookPayload = {
+      id: '01HRES',
+      created: '2026-04-16T00:00:00Z',
+      action: 'reservation.created',
+      version: '2023-03-02',
+      data: {
+        id: 'res_01',
+        platform: 'airbnb',
+        platformId: 'abb_r_123',
+        bookingDate: '2026-04-10',
+        arrivalDate: '2026-05-01',
+        departureDate: '2026-05-03',
+        status: 'accept',
+        statusHistory: [
+          { category: 'confirmed', status: 'accept', createdAt: '2026-04-10T00:00:00Z' },
+        ],
+        guests: { total: 2, adultCount: 2, childCount: 0, infantCount: 0, petCount: 0 },
+        guest: {
+          email: 'g@example.com',
+          phoneNumbers: ['+15555550200'],
+          firstName: 'Test',
+          lastName: 'User',
+          locale: 'en',
+        },
+        financials: {
+          guest: {
+            accommodation: financial,
+            cleaningFee: financial,
+            serviceFee: financial,
+            taxes: [],
+            fees: [],
+            totalFees: financial,
+            discounts: [],
+            subtotal: financial,
+            totalPrice: financial,
+          },
+          host: {
+            accommodation: financial,
+            cleaningFee: financial,
+            serviceFee: financial,
+            taxes: [],
+            fees: [],
+            totalFees: financial,
+            discounts: [],
+            subtotal: financial,
+            payout: financial,
+          },
+        },
+        listing: {
+          id: 'lst_01',
+          platform: 'airbnb',
+          platformId: 'abb_l_99',
+          publicName: 'Downtown Loft',
+          privateName: 'SF-Loft-01',
+          summary: '',
+          description: '',
+          roomType: 'entire_home',
+          propertyType: 'apartment',
+          picture: '',
+          address: {
+            street: '1 Market St',
+            zipcode: '94105',
+            city: 'San Francisco',
+            state: 'CA',
+            apt: '',
+            countryCode: 'US',
+            latitude: 0,
+            longitude: 0,
+          },
+          capacity: { max: 4, bedrooms: 1, beds: 1, bathrooms: 1 },
+          roomDetails: [],
+          bathrooms: 1,
+          bedrooms: 1,
+          available: 1,
+          channel,
+          channels: [channel],
+          fees: [],
+          amenities: [],
+          'check-in': null,
+          'check-out': null,
+          details: {
+            spaceOverview: null,
+            guestAccess: null,
+            houseManual: null,
+            notes: null,
+            additionalRules: null,
+            neighborhoodDescription: null,
+            gettingAround: null,
+            wifiName: null,
+            wifiPassword: null,
+          },
+          houseRules: { petsAllowed: false, smokingAllowed: false, eventsAllowed: false },
+        },
+        channel,
+        customer,
+      },
+    }
+    const generic: ConnectWebhookPayload = payload
+    if (isConnectWebhookAction(generic, 'reservation.created')) {
+      expect(generic.data.status).toBe('accept')
+      expect(generic.data.guests.total).toBe(2)
+      expect(generic.data.financials.host.payout.amount).toBe(25000)
+      expect(generic.data.listing.publicName).toBe('Downtown Loft')
+      expect(generic.data.channel.id).toBe('ch_01')
+      expect(generic.data.customer.timezone).toBe('America/Los_Angeles')
+    } else {
+      expect.unreachable()
+    }
+  })
+
+  it('review.published — narrows to Review with rating/visibility fields', () => {
+    const payload: ReviewWebhookPayload = {
+      id: '01HREV',
+      created: '2026-04-16T00:00:00Z',
+      action: 'review.published',
+      version: '2023-03-02',
+      data: {
+        id: 'rev_01',
+        platform: 'airbnb',
+        platformId: 'abb_rv_01',
+        reservationPlatformId: 'abb_r_123',
+        listingPlatformId: 'abb_l_99',
+        guestPlatformId: 'abb_g_01',
+        guestName: null,
+        reviewerRole: 'guest',
+        rating: 5,
+        detailedRatings: [{ rating: 5, comment: 'Clean', category: 'cleanliness' }],
+        visible: true,
+        publicText: 'Great stay',
+        privateText: null,
+        responseText: null,
+        expiresAt: '2026-05-01T00:00:00Z',
+        firstCompletedAt: '2026-04-15T00:00:00Z',
+        submittedAt: '2026-04-15T00:00:00Z',
+        respondedAt: null,
+        channel,
+      },
+    }
+    const generic: ConnectWebhookPayload = payload
+    if (isConnectWebhookFamily(generic, 'review')) {
+      expect(generic.data.rating).toBe(5)
+      expect(generic.data.visible).toBe(true)
+      expect(generic.data.detailedRatings[0]!.category).toBe('cleanliness')
+      expect(generic.data.channel.platform).toBe('airbnb')
+    } else {
+      expect.unreachable()
+    }
+  })
+
+  it('payout.created — narrows to Payout with transactions ledger', () => {
+    const payload: PayoutWebhookPayload = {
+      id: '01HPAY',
+      created: '2026-04-16T00:00:00Z',
+      action: 'payout.created',
+      version: '2023-03-02',
+      data: {
+        id: 'pay_01',
+        platform: 'airbnb',
+        platformId: 'abb_p_01',
+        bankAccount: '****1234',
+        reference: 'ref-01',
+        amount: financial,
+        date: '2026-04-16',
+        channel,
+        transactions: [
+          {
+            id: 'tx_01',
+            type: 'Reservation',
+            details: null,
+            reference: null,
+            currency: 'USD',
+            amount: financial,
+            date: '2026-04-16',
+            startDate: '2026-05-01',
+          },
+        ],
+      },
+    }
+    const generic: ConnectWebhookPayload = payload
+    if (isConnectWebhookAction(generic, 'payout.created')) {
+      expect(generic.data.amount.formatted).toBe('$250.00')
+      expect(generic.data.transactions[0]!.type).toBe('Reservation')
+    } else {
+      expect.unreachable()
+    }
+  })
+
+  it('transaction.created — narrows to Transaction with optional payout/listing/reservation', () => {
+    const payload: TransactionWebhookPayload = {
+      id: '01HTX',
+      created: '2026-04-16T00:00:00Z',
+      action: 'transaction.created',
+      version: '2023-03-02',
+      data: {
+        id: 'tx_02',
+        type: 'Adjustment',
+        details: 'goodwill credit',
+        reference: null,
+        currency: 'USD',
+        amount: financial,
+        date: '2026-04-16',
+        startDate: '2026-05-01',
+      },
+    }
+    const generic: ConnectWebhookPayload = payload
+    if (isConnectWebhookFamily(generic, 'transaction')) {
+      expect(generic.data.type).toBe('Adjustment')
+      expect(generic.data.details).toBe('goodwill credit')
+      expect(generic.data.payout).toBeUndefined()
+    } else {
+      expect.unreachable()
+    }
   })
 })

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -34,7 +34,7 @@ describe('HospitableError', () => {
 describe('AuthenticationError', () => {
   it('has correct name and statusCode', () => {
     const err = new AuthenticationError()
-    expect(err.name).toBe('AuthenticationError')
+    expect(err.name).toBe('HospitableAuthError')
     expect(err.statusCode).toBe(401)
     expect(err.message).toBe('Authentication failed')
   })
@@ -55,7 +55,7 @@ describe('AuthenticationError', () => {
 describe('RateLimitError', () => {
   it('has correct name, statusCode, retryAfter, and message', () => {
     const err = new RateLimitError(30)
-    expect(err.name).toBe('RateLimitError')
+    expect(err.name).toBe('HospitableRateLimitError')
     expect(err.statusCode).toBe(429)
     expect(err.retryAfter).toBe(30)
     expect(err.message).toBe('Rate limit exceeded. Retry after 30s')
@@ -76,7 +76,7 @@ describe('RateLimitError', () => {
 describe('NotFoundError', () => {
   it('has correct name and statusCode with defaults', () => {
     const err = new NotFoundError()
-    expect(err.name).toBe('NotFoundError')
+    expect(err.name).toBe('HospitableNotFoundError')
     expect(err.statusCode).toBe(404)
     expect(err.message).toBe('Resource not found')
     expect(err.resource).toBeUndefined()
@@ -99,7 +99,7 @@ describe('NotFoundError', () => {
 describe('ValidationError', () => {
   it('has correct name and statusCode with empty fields default', () => {
     const err = new ValidationError('Invalid input')
-    expect(err.name).toBe('ValidationError')
+    expect(err.name).toBe('HospitableValidationError')
     expect(err.statusCode).toBe(422)
     expect(err.message).toBe('Invalid input')
     expect(err.fields).toEqual({})
@@ -122,7 +122,7 @@ describe('ValidationError', () => {
 describe('ForbiddenError', () => {
   it('has correct name and statusCode with default message', () => {
     const err = new ForbiddenError()
-    expect(err.name).toBe('ForbiddenError')
+    expect(err.name).toBe('HospitableForbiddenError')
     expect(err.statusCode).toBe(403)
     expect(err.message).toBe('Forbidden')
   })
@@ -138,12 +138,35 @@ describe('ForbiddenError', () => {
     expect(err).toBeInstanceOf(HospitableError)
     expect(err).toBeInstanceOf(ForbiddenError)
   })
+
+  it('is instanceof AuthenticationError (AGENTS.md: HospitableAuthError covers 401 and 403)', () => {
+    const err = new ForbiddenError()
+    expect(err).toBeInstanceOf(AuthenticationError)
+  })
+})
+
+describe('HospitableAuthError alias (401/403)', () => {
+  it('catches a 401 AuthenticationError', () => {
+    const err = createErrorFromResponse(401, { message: 'no creds' })
+    expect(err).toBeInstanceOf(AuthenticationError)
+  })
+
+  it('catches a 403 ForbiddenError via AuthenticationError ancestor', () => {
+    // This is the AGENTS.md §Error Handling behavior: a consumer who does
+    //   catch (err) { if (err instanceof HospitableAuthError) ... }
+    // must see 403 caught in that branch. Since HospitableAuthError aliases
+    // AuthenticationError and ForbiddenError extends AuthenticationError,
+    // the 403 path lands here.
+    const err = createErrorFromResponse(403, { message: 'not allowed' })
+    expect(err).toBeInstanceOf(ForbiddenError)
+    expect(err).toBeInstanceOf(AuthenticationError)
+  })
 })
 
 describe('ServerError', () => {
   it('has correct name, statusCode, and attempts', () => {
     const err = new ServerError('Internal error', 500, 3)
-    expect(err.name).toBe('ServerError')
+    expect(err.name).toBe('HospitableServerError')
     expect(err.statusCode).toBe(500)
     expect(err.attempts).toBe(3)
     expect(err.message).toBe('Internal error')

--- a/src/__tests__/retry.test.ts
+++ b/src/__tests__/retry.test.ts
@@ -251,6 +251,46 @@ describe('withRetry', () => {
     expect((err as RateLimitError).retryAfter).toBe(1)
   })
 
+  it('applies exponential backoff across attempts (issue #51)', async () => {
+    // Regression guard for AGENTS.md §Safety: backoff on 429 MUST be
+    // exponential, not linear. A prior test asserted jitter only (two
+    // runs produce different values), which a linear implementation
+    // would also pass. This one asserts delay growth across attempts.
+    const delays: number[] = []
+    const realSetTimeout = globalThis.setTimeout
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((cb: () => void, delay?: number) => {
+      delays.push(delay ?? 0)
+      return realSetTimeout(cb, 0)
+    }) as unknown as typeof globalThis.setTimeout)
+
+    // Fix Math.random() to 0.5 → jitter factor = 0.25 * (0.5*2 - 1) = 0
+    // So delay = exponential = baseDelay * 2^(attempt-1), with no jitter noise.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new FakeHttpError(500, 'boom'))
+      .mockRejectedValueOnce(new FakeHttpError(500, 'boom'))
+      .mockRejectedValueOnce(new FakeHttpError(500, 'boom'))
+      .mockResolvedValueOnce({ ok: true })
+
+    const promise = withRetry(fn, '/test', {
+      maxAttempts: 4,
+      baseDelay: 1000,
+      maxDelay: 60_000,
+    })
+    await vi.runAllTimersAsync()
+    await promise
+
+    expect(delays).toHaveLength(3)
+    // Expected (no jitter): 1000, 2000, 4000
+    expect(delays[0]).toBeCloseTo(1000, -1)
+    expect(delays[1]).toBeCloseTo(2000, -1)
+    expect(delays[2]).toBeCloseTo(4000, -1)
+    // Growth assertions independent of exact values — would fail linear (1000, 2000, 3000)
+    expect(delays[1]!).toBeGreaterThan(delays[0]! * 1.5)
+    expect(delays[2]!).toBeGreaterThan(delays[1]! * 1.5)
+  })
+
   it('onRateLimit fires on each 429 with incrementing attempt number', async () => {
     const onRateLimit = vi.fn()
     const fn = vi.fn()

--- a/src/__tests__/token-manager.test.ts
+++ b/src/__tests__/token-manager.test.ts
@@ -96,7 +96,7 @@ describe('TokenManager', () => {
       )
     })
 
-    it('4. refreshes when expiresAt is in the past', async () => {
+    it('4. refreshes when caller signals a stale token via expiresIn', async () => {
       const mockFetch = makeFetchMock({
         ok: true,
         json: () => Promise.resolve(makeTokenResponse({ expires_in: -1 })),
@@ -109,12 +109,9 @@ describe('TokenManager', () => {
         clientId: 'client-id',
         clientSecret: 'client-secret',
         baseURL: 'https://api.hospitable.com',
+        expiresIn: 0,
       })
 
-      // Force expiresAt to the past by getting auth header first time
-      // The constructor sets expiresAt = Date.now() + 60_000 for OAuth mode
-      // but needsRefresh checks Date.now() >= expiresAt - 60_000
-      // So with expiresAt = now + 60_000, needsRefresh = now >= now = true
       const header = await tm.getAuthHeader()
 
       expect(mockFetch).toHaveBeenCalledOnce()
@@ -122,6 +119,28 @@ describe('TokenManager', () => {
       const body = (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string
       expect(body).toContain('grant_type=refresh_token')
       expect(body).toContain('refresh_token=old-refresh')
+    })
+
+    it('4b. assumes caller-supplied token is fresh by default (no refresh on first use)', async () => {
+      // Regression guard for #54: prior to the fix, expiresAt was hardcoded
+      // to now+60_000, which combined with the 60-second refresh margin in
+      // needsRefresh() caused an immediate refresh on the very first call.
+      // With the 3600-second default, the token is trusted until it ages out.
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      const tm = new TokenManager({
+        token: 'fresh-token',
+        refreshToken: 'some-refresh',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        baseURL: 'https://api.hospitable.com',
+      })
+
+      const header = await tm.getAuthHeader()
+
+      expect(header).toBe('Bearer fresh-token')
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('5. deduplicates concurrent refresh calls — fetch called only once', async () => {
@@ -231,6 +250,9 @@ describe('TokenManager', () => {
         clientId: 'client-id',
         clientSecret: 'client-secret',
         baseURL: 'https://api.hospitable.com',
+        // Mark the provided token as stale so the first getAuthHeader
+        // call triggers an immediate refresh (the scenario under test).
+        expiresIn: 0,
       })
 
       // First call: refresh using initial-refresh, server returns new-refresh-token

--- a/src/auth/token-manager.ts
+++ b/src/auth/token-manager.ts
@@ -6,6 +6,15 @@ export interface TokenManagerConfig {
   clientId?: string
   clientSecret?: string
   baseURL: string
+  /**
+   * Seconds until the caller-supplied `token` expires. Only consulted when
+   * both `token` and `refreshToken` are provided (OAuth rehydrate path).
+   * Defaults to 3600 — a conservative "fresh" assumption. Pass the server's
+   * `expires_in` response directly if you have it; pass a small value only
+   * when you know the token is near-expiry and want to force a proactive
+   * refresh on the next request.
+   */
+  expiresIn?: number
 }
 
 interface OAuthTokenResponse {
@@ -31,7 +40,8 @@ export class TokenManager {
     } else if (config.token) {
       this.accessToken = config.token
       this.refreshToken = config.refreshToken
-      this.expiresAt = Date.now() + 60_000
+      const ttlSeconds = config.expiresIn ?? 3600
+      this.expiresAt = Date.now() + ttlSeconds * 1000
     } else {
       const envPat = process.env['HOSPITABLE_API_PAT']
       if (envPat) {

--- a/src/connect/client.ts
+++ b/src/connect/client.ts
@@ -27,6 +27,25 @@ export interface HospitableConnectClientConfig {
   retry?: RetryConfig
   /** Enable debug logging. */
   debug?: boolean
+  /**
+   * Optional callback invoked when a 401 is returned by the API. Should
+   * resolve to a freshly-minted bearer token, which the SDK will swap in
+   * and use to transparently retry the failing request.
+   *
+   * Without this callback, 401s throw {@link AuthenticationError} and the
+   * caller must reconstruct the client — fine for short-lived scripts but
+   * a dead-end for long-running agent processes that rotate tokens
+   * mid-session. Supply it to cover that case.
+   *
+   * @example
+   * ```ts
+   * new HospitableConnectClient({
+   *   token: initialToken,
+   *   onTokenExpired: () => fetchFreshConnectToken(),
+   * })
+   * ```
+   */
+  onTokenExpired?: () => string | Promise<string>
 }
 
 /**
@@ -35,9 +54,11 @@ export interface HospitableConnectClientConfig {
  * host-facing).
  *
  * Auth is a static bearer token minted in the Hospitable Partner Portal;
- * there is no OAuth refresh loop. 401s surface as
- * {@link AuthenticationError} — regenerate the token in the portal and
- * reconstruct the client.
+ * there is no OAuth refresh loop. By default, 401s surface as
+ * {@link AuthenticationError} and are terminal — regenerate the token in
+ * the portal and reconstruct the client. Supply {@link HospitableConnectClientConfig.onTokenExpired}
+ * to plug in a custom refresh path (e.g. for long-running agents that
+ * rotate tokens via an external system).
  *
  * @see https://developer.hospitable.com/docs/connect-api-docs
  */
@@ -65,9 +86,21 @@ export class HospitableConnectClient {
       )
     }
 
+    // Hold the current token in a mutable ref so `onTokenExpired` can rotate
+    // it in place without reconstructing the client. `getAuthHeader` reads
+    // through the ref on every request.
+    let currentToken = token
+
     const http = new HttpClient({
       baseURL,
-      getAuthHeader: async () => `Bearer ${token}`,
+      getAuthHeader: async () => `Bearer ${currentToken}`,
+      ...(config.onTokenExpired !== undefined
+        ? {
+            onUnauthorized: async () => {
+              currentToken = await config.onTokenExpired!()
+            },
+          }
+        : {}),
       ...(config.debug !== undefined ? { debug: config.debug } : {}),
       ...(config.retry !== undefined ? { retryConfig: config.retry } : {}),
     })

--- a/src/connect/filter.ts
+++ b/src/connect/filter.ts
@@ -29,6 +29,37 @@ const MULTI_VALUE_OPS = new Set<ConnectFilterOperator>(['is', 'not'])
 const SINGLE_VALUE_OPS = new Set<ConnectFilterOperator>(['lt', 'lte', 'gt', 'gte', 'before', 'after'])
 
 /**
+ * Allowlisted shape for field identifiers. Letters, digits, underscore,
+ * and dot (for nested paths like `financials.host`). Must start with a
+ * letter or underscore.
+ *
+ * Enforced on every `field` argument across `where`, `sortAsc`,
+ * `sortDesc`, and `select` to block two classes of defect:
+ *
+ * 1. **Log injection.** Without the guard, a field value containing
+ *    newlines / ANSI control codes flows into `ConfigurationError.message`
+ *    and then into any structured-log sink the caller uses (Sentry,
+ *    CloudWatch, etc.). AI agents composing filters from LLM output
+ *    are the realistic attack surface.
+ * 2. **Param-key corruption.** A field containing `]` or `[` would
+ *    produce a malformed `field[operator]` key that the API would reject
+ *    with an unhelpful 400 deep in the request pipeline.
+ *
+ * The error message deliberately does NOT echo the offending `field`
+ * value (that's the defect the guard is preventing).
+ */
+const FIELD_PATTERN = /^[A-Za-z_][\w.]*$/
+
+function assertValidField(field: string): void {
+  if (!FIELD_PATTERN.test(field)) {
+    throw new ConfigurationError(
+      `ConnectFilter: field name must match ${FIELD_PATTERN.source} ` +
+        '(letters, digits, underscore, dot; must start with a letter or underscore).',
+    )
+  }
+}
+
+/**
  * Fluent, immutable builder for Connect list params — composes
  * `field[operator]=value` filters, `sort[asc|desc]=field`, `_select=`,
  * and pagination (page / perPage).
@@ -71,6 +102,8 @@ export class ConnectFilter {
     operator: ConnectFilterOperator,
     value: string | number | boolean | Array<string | number | boolean>,
   ): ConnectFilter {
+    assertValidField(field)
+
     const stringified = Array.isArray(value)
       ? value.map(v => String(v)).join(',')
       : String(value)
@@ -94,8 +127,24 @@ export class ConnectFilter {
       if (Array.isArray(value)) {
         throw new ConfigurationError(
           `ConnectFilter.where: \`${operator}\` takes a single value — received an array. ` +
-            `Example: .where('${field}', '${operator}', '2024-02-01').`,
+            `Example: .where('<field>', '${operator}', '2024-02-01').`,
         )
+      }
+    }
+
+    // Comma is the multi-value delimiter on `is`, `not`, and `between`.
+    // A value containing a literal comma (e.g. 'San Francisco, CA') would
+    // silently split into two values when the API parses the query string,
+    // so reject it up front rather than producing an ambiguous filter.
+    if (Array.isArray(value) && (MULTI_VALUE_OPS.has(operator) || operator === 'between')) {
+      for (const v of value) {
+        if (typeof v === 'string' && v.includes(',')) {
+          throw new ConfigurationError(
+            `ConnectFilter.where: \`${operator}\` values cannot contain commas — ` +
+              'comma is the multi-value delimiter in the Connect query syntax. ' +
+              'Split the value into separate filters or normalize it before passing.',
+          )
+        }
       }
     }
 
@@ -107,6 +156,7 @@ export class ConnectFilter {
 
   /** Sort ascending by `field`. Replaces any prior sort. */
   sortAsc(field: string): ConnectFilter {
+    assertValidField(field)
     const next = this.stripSort()
     next[`sort[asc]`] = field
     return new ConnectFilter(next)
@@ -114,6 +164,7 @@ export class ConnectFilter {
 
   /** Sort descending by `field`. Replaces any prior sort. */
   sortDesc(field: string): ConnectFilter {
+    assertValidField(field)
     const next = this.stripSort()
     next[`sort[desc]`] = field
     return new ConnectFilter(next)
@@ -136,6 +187,7 @@ export class ConnectFilter {
   /** Request only a subset of response fields via `_select=a,b,c`. */
   select(...fields: string[]): ConnectFilter {
     if (fields.length === 0) return this
+    fields.forEach(assertValidField)
     return new ConnectFilter({ ...this.state, _select: fields.join(',') })
   }
 

--- a/src/connect/index.ts
+++ b/src/connect/index.ts
@@ -10,3 +10,8 @@ export type { ConnectFilterOperator } from './filter'
 
 export { paginateConnect } from './paginate'
 export type { ConnectPageFetcher } from './paginate'
+
+// `collectAll` works on any AsyncIterable (including the generator returned
+// by `paginateConnect`), so it's re-exported here for namespace symmetry —
+// `import { Connect } from 'hospitable'` → `Connect.collectAll(...)` just works.
+export { collectAll } from '../http/paginate'

--- a/src/connect/resources/payouts.ts
+++ b/src/connect/resources/payouts.ts
@@ -6,7 +6,8 @@ export interface PayoutListParams {
   page?: number
   perPage?: number
   _select?: string
-  [key: string]: string | number | boolean | string[] | undefined
+  /** Free-form `field[operator]=value` filter bag. See issue #49 for the `string[]` exclusion rationale. */
+  [key: string]: string | number | boolean | undefined
 }
 
 /**

--- a/src/connect/resources/reservations.ts
+++ b/src/connect/resources/reservations.ts
@@ -12,8 +12,15 @@ export interface ReservationListParams {
    * by `arrival_date[after]=2026-01-01` pass
    * `{ 'arrival_date[after]': '2026-01-01' }`. Use `ConnectFilter` for
    * a typed builder.
+   *
+   * Value type intentionally excludes `string[]`: Connect's filter
+   * serialization is comma-joined strings (see `ConnectFilter.where`),
+   * so arrays should be pre-joined before hitting this bag. Allowing
+   * `string[]` here also accidentally satisfied the numeric `page` /
+   * `perPage` slots at compile time, producing silent `NaN` paginator
+   * loops — see issue #49.
    */
-  [key: string]: string | number | boolean | string[] | undefined
+  [key: string]: string | number | boolean | undefined
 }
 
 /**

--- a/src/connect/resources/resolutions.ts
+++ b/src/connect/resources/resolutions.ts
@@ -6,7 +6,8 @@ export interface ResolutionListParams {
   page?: number
   perPage?: number
   _select?: string
-  [key: string]: string | number | boolean | string[] | undefined
+  /** Free-form `field[operator]=value` filter bag. See issue #49 for the `string[]` exclusion rationale. */
+  [key: string]: string | number | boolean | undefined
 }
 
 /**

--- a/src/connect/resources/reviews.ts
+++ b/src/connect/resources/reviews.ts
@@ -6,7 +6,8 @@ export interface ReviewListParams {
   page?: number
   perPage?: number
   _select?: string
-  [key: string]: string | number | boolean | string[] | undefined
+  /** Free-form `field[operator]=value` filter bag. See issue #49 for the `string[]` exclusion rationale. */
+  [key: string]: string | number | boolean | undefined
 }
 
 /**

--- a/src/connect/resources/transactions.ts
+++ b/src/connect/resources/transactions.ts
@@ -6,7 +6,8 @@ export interface TransactionListParams {
   page?: number
   perPage?: number
   _select?: string
-  [key: string]: string | number | boolean | string[] | undefined
+  /** Free-form `field[operator]=value` filter bag. See issue #49 for the `string[]` exclusion rationale. */
+  [key: string]: string | number | boolean | undefined
 }
 
 /**

--- a/src/connect/webhooks/index.ts
+++ b/src/connect/webhooks/index.ts
@@ -21,3 +21,10 @@ export type {
 } from './types'
 
 export { isConnectWebhookAction, isConnectWebhookFamily } from './types'
+
+export { verifyWebhookSignature } from './verify'
+export type {
+  VerifyWebhookSignatureOptions,
+  WebhookSignatureAlgorithm,
+  WebhookSignatureEncoding,
+} from './verify'

--- a/src/connect/webhooks/types.ts
+++ b/src/connect/webhooks/types.ts
@@ -14,6 +14,13 @@ import type { Customer } from '../models/customer'
  *
  * Return 200 to acknowledge receipt — the platform retries on any
  * non-2xx response.
+ *
+ * ⚠️  **Security.** The type guards ({@link isConnectWebhookAction},
+ * {@link isConnectWebhookFamily}) only narrow the shape — they do NOT
+ * authenticate the sender. Anyone who discovers your webhook URL can POST
+ * a forged body that passes both guards. Before trusting any incoming
+ * payload, verify its HMAC signature with {@link verifyWebhookSignature}
+ * using the shared secret from your Hospitable integration.
  */
 export interface ConnectWebhookEnvelope<Action extends string, Data> {
   id: string

--- a/src/connect/webhooks/verify.ts
+++ b/src/connect/webhooks/verify.ts
@@ -1,5 +1,3 @@
-import { createHmac, timingSafeEqual } from 'node:crypto'
-
 /**
  * Digest algorithm used to compute the HMAC. `sha256` is the default and
  * what Hospitable uses; `sha1` is supported only for legacy compatibility.
@@ -19,11 +17,14 @@ export interface VerifyWebhookSignatureOptions {
    * JSON — the byte-for-byte original is required for the HMAC to match.
    * Most frameworks expose this as `req.rawBody`, `request.body` (when
    * configured for raw), or the result of a `body-parser`-style raw reader.
+   *
+   * Node's `Buffer` is accepted transparently since it extends
+   * `Uint8Array`; the SDK itself doesn't depend on `@types/node`.
    */
-  rawBody: string | Buffer | Uint8Array
+  rawBody: string | Uint8Array
   /**
    * The signature header value received from Hospitable. If the header
-   * contains a `algo=` prefix (e.g. `sha256=abc123…`), it is stripped
+   * contains an `algo=` prefix (e.g. `sha256=abc123…`), it is stripped
    * automatically before comparison.
    */
   signatureHeader: string
@@ -60,26 +61,30 @@ export interface VerifyWebhookSignatureOptions {
  * URL can forge events and trigger arbitrary downstream behavior in your
  * tenant.
  *
- * Returns `true` when the signature is valid and (if supplied) the
- * timestamp is within tolerance. Returns `false` for any mismatch, malformed
- * input, or stale payload. Never throws for signature mismatch — throwing
- * on verification failure invites a DoS where crafted bodies crash the
- * receiver.
+ * Resolves to `true` when the signature is valid and (if supplied) the
+ * timestamp is within tolerance. Resolves to `false` for any mismatch,
+ * malformed input, or stale payload. Never throws for signature mismatch
+ * — throwing on verification failure invites a DoS where crafted bodies
+ * crash the receiver.
  *
- * Uses `crypto.timingSafeEqual` for the comparison to prevent side-channel
- * leaks of the expected signature byte-by-byte.
+ * Uses a constant-time comparison to prevent side-channel leaks of the
+ * expected signature byte-by-byte.
+ *
+ * Implemented via Web Crypto (`globalThis.crypto.subtle`) so the SDK
+ * stays free of `@types/node`. Works on Node 20+ (native) and in any
+ * runtime that ships Web Crypto.
  *
  * @example
  * ```ts
  * // Express route handler — be sure to capture the raw body.
- * app.post('/webhooks/hospitable', express.raw({ type: 'application/json' }), (req, res) => {
- *   const ok = verifyWebhookSignature({
+ * app.post('/webhooks/hospitable', express.raw({ type: 'application/json' }), async (req, res) => {
+ *   const ok = await verifyWebhookSignature({
  *     rawBody: req.body,
  *     signatureHeader: req.header('X-Hospitable-Signature') ?? '',
  *     secret: process.env.HOSPITABLE_WEBHOOK_SECRET!,
  *   })
  *   if (!ok) return res.status(401).end()
- *   const payload = JSON.parse(req.body.toString('utf8'))
+ *   const payload = JSON.parse(new TextDecoder().decode(req.body))
  *   // ... handle payload ...
  *   res.status(200).end()
  * })
@@ -87,7 +92,9 @@ export interface VerifyWebhookSignatureOptions {
  *
  * @see https://developer.hospitable.com/docs/connect-api-docs
  */
-export function verifyWebhookSignature(opts: VerifyWebhookSignatureOptions): boolean {
+export async function verifyWebhookSignature(
+  opts: VerifyWebhookSignatureOptions,
+): Promise<boolean> {
   const {
     rawBody,
     signatureHeader,
@@ -107,34 +114,84 @@ export function verifyWebhookSignature(opts: VerifyWebhookSignatureOptions): boo
     if (ageSeconds > toleranceSeconds) return false
   }
 
-  const bodyBytes = coerceToBuffer(rawBody)
+  const bodyBytes = toBytes(rawBody)
   const signedPayload =
-    timestamp !== undefined
-      ? Buffer.concat([Buffer.from(`${timestamp}.`, 'utf8'), bodyBytes])
-      : bodyBytes
+    timestamp !== undefined ? concatBytes(toBytes(`${timestamp}.`), bodyBytes) : bodyBytes
 
-  const expected = createHmac(algorithm, secret).update(signedPayload).digest()
+  const encoder = new TextEncoder()
+  const keyMaterial = encoder.encode(secret)
+  // Cast to ArrayBuffer: TextEncoder.encode returns Uint8Array<ArrayBufferLike>
+  // in newer TS lib, but Web Crypto's BufferSource requires ArrayBuffer-backed.
+  // The underlying buffer is always ArrayBuffer (never SharedArrayBuffer) in
+  // this code path, so the cast is runtime-safe.
+  const key = await crypto.subtle.importKey(
+    'raw',
+    keyMaterial.buffer as ArrayBuffer,
+    { name: 'HMAC', hash: { name: algorithm === 'sha1' ? 'SHA-1' : 'SHA-256' } },
+    false,
+    ['sign'],
+  )
+  const expected = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, signedPayload.buffer as ArrayBuffer),
+  )
 
-  // Strip an algo prefix like `sha256=…` that some providers include.
-  // Only strip when the leading segment is a short alphanumeric name
-  // followed by `=` — otherwise a base64 header with padding (`=` chars)
-  // would be incorrectly truncated.
   const prefixMatch = signatureHeader.match(/^[A-Za-z][A-Za-z0-9]{1,15}=(.+)$/)
   const headerValue = prefixMatch ? prefixMatch[1]! : signatureHeader
 
-  let provided: Buffer
-  try {
-    provided = Buffer.from(headerValue, encoding)
-  } catch {
-    return false
-  }
-
+  const provided = decodeSignature(headerValue, encoding)
+  if (provided === null) return false
   if (provided.length !== expected.length) return false
-  return timingSafeEqual(provided, expected)
+  return constantTimeEqual(provided, expected)
 }
 
-function coerceToBuffer(body: string | Buffer | Uint8Array): Buffer {
-  if (typeof body === 'string') return Buffer.from(body, 'utf8')
-  if (Buffer.isBuffer(body)) return body
-  return Buffer.from(body)
+function toBytes(body: string | Uint8Array): Uint8Array {
+  if (typeof body === 'string') return new TextEncoder().encode(body)
+  // Copy into a fresh, tightly-bounded Uint8Array. Node's `Buffer` is a
+  // subclass of Uint8Array but shares an underlying pool across many
+  // Buffer instances — `buf.buffer` can be much larger than the logical
+  // bytes of `buf`, with `byteOffset` / `byteLength` carving out the
+  // slice. `crypto.subtle.sign(..., buf.buffer)` would then sign the
+  // entire pool, producing a wrong HMAC. The copy here normalizes any
+  // input (Buffer or plain Uint8Array) to an exact-length ArrayBuffer.
+  const out = new Uint8Array(body.length)
+  out.set(body)
+  return out
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length)
+  out.set(a, 0)
+  out.set(b, a.length)
+  return out
+}
+
+function decodeSignature(
+  value: string,
+  encoding: WebhookSignatureEncoding,
+): Uint8Array | null {
+  if (encoding === 'hex') {
+    if (value.length === 0 || value.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(value)) {
+      return null
+    }
+    const out = new Uint8Array(value.length / 2)
+    for (let i = 0; i < out.length; i++) {
+      out[i] = parseInt(value.slice(i * 2, i * 2 + 2), 16)
+    }
+    return out
+  }
+  // base64
+  try {
+    const binary = atob(value)
+    const out = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+    return out
+  } catch {
+    return null
+  }
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  let diff = 0
+  for (let i = 0; i < a.length; i++) diff |= a[i]! ^ b[i]!
+  return diff === 0
 }

--- a/src/connect/webhooks/verify.ts
+++ b/src/connect/webhooks/verify.ts
@@ -1,0 +1,140 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+/**
+ * Digest algorithm used to compute the HMAC. `sha256` is the default and
+ * what Hospitable uses; `sha1` is supported only for legacy compatibility.
+ */
+export type WebhookSignatureAlgorithm = 'sha256' | 'sha1'
+
+/**
+ * Encoding of the signature as sent in the HTTP header. Hex is the
+ * Hospitable default; base64 is supported for callers who bridge from
+ * other webhook providers.
+ */
+export type WebhookSignatureEncoding = 'hex' | 'base64'
+
+export interface VerifyWebhookSignatureOptions {
+  /**
+   * The raw request body, exactly as received. Do NOT pass the parsed
+   * JSON — the byte-for-byte original is required for the HMAC to match.
+   * Most frameworks expose this as `req.rawBody`, `request.body` (when
+   * configured for raw), or the result of a `body-parser`-style raw reader.
+   */
+  rawBody: string | Buffer | Uint8Array
+  /**
+   * The signature header value received from Hospitable. If the header
+   * contains a `algo=` prefix (e.g. `sha256=abc123…`), it is stripped
+   * automatically before comparison.
+   */
+  signatureHeader: string
+  /**
+   * The shared secret configured when the webhook was registered in the
+   * Hospitable Partner Portal. Store this in an env var or secret manager
+   * — never hardcode it.
+   */
+  secret: string
+  /** Defaults to `'sha256'`. */
+  algorithm?: WebhookSignatureAlgorithm
+  /** Defaults to `'hex'`. */
+  encoding?: WebhookSignatureEncoding
+  /**
+   * Optional timestamp header value. When supplied, the signed payload is
+   * `` `${timestamp}.${rawBody}` `` — a common anti-replay scheme. Pair
+   * this with {@link toleranceSeconds} to reject stale deliveries.
+   */
+  timestamp?: string
+  /**
+   * Maximum age in seconds allowed for a timestamped payload. Signatures
+   * older than this (relative to `Date.now()`) are rejected. Only consulted
+   * when {@link timestamp} is provided. Defaults to 300 (5 minutes).
+   */
+  toleranceSeconds?: number
+}
+
+/**
+ * Verify the HMAC signature on an incoming Hospitable Connect webhook.
+ *
+ * Hospitable signs every webhook delivery with a shared secret; verifying
+ * the signature is the caller's responsibility and is mandatory for any
+ * production integration — without it, an attacker who knows your webhook
+ * URL can forge events and trigger arbitrary downstream behavior in your
+ * tenant.
+ *
+ * Returns `true` when the signature is valid and (if supplied) the
+ * timestamp is within tolerance. Returns `false` for any mismatch, malformed
+ * input, or stale payload. Never throws for signature mismatch — throwing
+ * on verification failure invites a DoS where crafted bodies crash the
+ * receiver.
+ *
+ * Uses `crypto.timingSafeEqual` for the comparison to prevent side-channel
+ * leaks of the expected signature byte-by-byte.
+ *
+ * @example
+ * ```ts
+ * // Express route handler — be sure to capture the raw body.
+ * app.post('/webhooks/hospitable', express.raw({ type: 'application/json' }), (req, res) => {
+ *   const ok = verifyWebhookSignature({
+ *     rawBody: req.body,
+ *     signatureHeader: req.header('X-Hospitable-Signature') ?? '',
+ *     secret: process.env.HOSPITABLE_WEBHOOK_SECRET!,
+ *   })
+ *   if (!ok) return res.status(401).end()
+ *   const payload = JSON.parse(req.body.toString('utf8'))
+ *   // ... handle payload ...
+ *   res.status(200).end()
+ * })
+ * ```
+ *
+ * @see https://developer.hospitable.com/docs/connect-api-docs
+ */
+export function verifyWebhookSignature(opts: VerifyWebhookSignatureOptions): boolean {
+  const {
+    rawBody,
+    signatureHeader,
+    secret,
+    algorithm = 'sha256',
+    encoding = 'hex',
+    timestamp,
+    toleranceSeconds = 300,
+  } = opts
+
+  if (!signatureHeader || !secret) return false
+
+  if (timestamp !== undefined) {
+    const ts = Number(timestamp)
+    if (!Number.isFinite(ts)) return false
+    const ageSeconds = Math.abs(Date.now() / 1000 - ts)
+    if (ageSeconds > toleranceSeconds) return false
+  }
+
+  const bodyBytes = coerceToBuffer(rawBody)
+  const signedPayload =
+    timestamp !== undefined
+      ? Buffer.concat([Buffer.from(`${timestamp}.`, 'utf8'), bodyBytes])
+      : bodyBytes
+
+  const expected = createHmac(algorithm, secret).update(signedPayload).digest()
+
+  // Strip an algo prefix like `sha256=…` that some providers include.
+  // Only strip when the leading segment is a short alphanumeric name
+  // followed by `=` — otherwise a base64 header with padding (`=` chars)
+  // would be incorrectly truncated.
+  const prefixMatch = signatureHeader.match(/^[A-Za-z][A-Za-z0-9]{1,15}=(.+)$/)
+  const headerValue = prefixMatch ? prefixMatch[1]! : signatureHeader
+
+  let provided: Buffer
+  try {
+    provided = Buffer.from(headerValue, encoding)
+  } catch {
+    return false
+  }
+
+  if (provided.length !== expected.length) return false
+  return timingSafeEqual(provided, expected)
+}
+
+function coerceToBuffer(body: string | Buffer | Uint8Array): Buffer {
+  if (typeof body === 'string') return Buffer.from(body, 'utf8')
+  if (Buffer.isBuffer(body)) return body
+  return Buffer.from(body)
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,10 +13,23 @@ export class HospitableError extends Error {
   }
 }
 
+/**
+ * Thrown on 401 and 403 responses. AGENTS.md §Error Handling spec mandates
+ * a single `HospitableAuthError` covering both. `ForbiddenError` extends
+ * this class so `err instanceof HospitableAuthError` catches 403 too.
+ *
+ * The trailing `statusCode` parameter exists so {@link ForbiddenError} can
+ * reuse the same constructor without duplicating the readonly-field dance.
+ * Callers should prefer {@link ForbiddenError} over `new AuthenticationError(…, 403)`.
+ */
 export class AuthenticationError extends HospitableError {
-  constructor(message = 'Authentication failed', requestId?: string) {
-    super(message, 401, requestId)
-    this.name = 'AuthenticationError'
+  constructor(
+    message = 'Authentication failed',
+    requestId?: string,
+    statusCode: 401 | 403 = 401,
+  ) {
+    super(message, statusCode, requestId)
+    this.name = 'HospitableAuthError'
   }
 }
 
@@ -25,7 +38,7 @@ export class RateLimitError extends HospitableError {
 
   constructor(retryAfter: number, requestId?: string) {
     super(`Rate limit exceeded. Retry after ${retryAfter}s`, 429, requestId)
-    this.name = 'RateLimitError'
+    this.name = 'HospitableRateLimitError'
     this.retryAfter = retryAfter
   }
 }
@@ -35,7 +48,7 @@ export class NotFoundError extends HospitableError {
 
   constructor(message = 'Resource not found', requestId?: string, resource?: string) {
     super(message, 404, requestId)
-    this.name = 'NotFoundError'
+    this.name = 'HospitableNotFoundError'
     this.resource = resource
   }
 }
@@ -45,15 +58,15 @@ export class ValidationError extends HospitableError {
 
   constructor(message: string, fields: Record<string, string[]> = {}, requestId?: string) {
     super(message, 422, requestId)
-    this.name = 'ValidationError'
+    this.name = 'HospitableValidationError'
     this.fields = fields
   }
 }
 
-export class ForbiddenError extends HospitableError {
+export class ForbiddenError extends AuthenticationError {
   constructor(message = 'Forbidden', requestId?: string) {
-    super(message, 403, requestId)
-    this.name = 'ForbiddenError'
+    super(message, requestId, 403)
+    this.name = 'HospitableForbiddenError'
   }
 }
 
@@ -62,7 +75,7 @@ export class ServerError extends HospitableError {
 
   constructor(message: string, statusCode: number, attempts: number, requestId?: string) {
     super(message, statusCode, requestId)
-    this.name = 'ServerError'
+    this.name = 'HospitableServerError'
     this.attempts = attempts
   }
 }
@@ -79,7 +92,7 @@ export class ServerError extends HospitableError {
 export class ConfigurationError extends HospitableError {
   constructor(message: string) {
     super(message, 0)
-    this.name = 'ConfigurationError'
+    this.name = 'HospitableConfigurationError'
   }
 }
 
@@ -101,20 +114,11 @@ export function createErrorFromResponse(
       return new NotFoundError(message, requestId)
     case 400:
     case 422: {
-      // Sanitize before storing on the error instance — the raw `errors`
-      // object can echo back guest PII (e.g. `body[name]: "Invalid: Jane"`)
-      // or business identity (`tax_id: "The tax id '12-3456789' is ..."`)
-      // and any consumer that logs the caught error via Sentry/winston
-      // would leak it. Sanitize at construction so the default code path
-      // never touches an unredacted error body.
       const rawErrors = (body['errors'] as Record<string, string[]> | undefined) ?? {}
       const errors = sanitize(rawErrors) as Record<string, string[]>
       return new ValidationError(message, errors, requestId)
     }
     case 429: {
-      // Prefer the HTTP `Retry-After` header (RFC 6585, threaded in via
-      // retryAfterOverride) over any JSON body field — the Hospitable API
-      // returns this as a header, not a body key.
       const retryAfter =
         retryAfterOverride ??
         (body['retryAfter'] as number | undefined) ??

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,11 +28,16 @@ export {
 
 // Aliases mandated by AGENTS.md — existing short names are retained for
 // backward compatibility; these let consumers catch by the spec names.
+// `ForbiddenError extends AuthenticationError`, so `instanceof HospitableAuthError`
+// catches both 401 and 403 per the AGENTS.md spec.
 export {
   AuthenticationError as HospitableAuthError,
+  ForbiddenError as HospitableForbiddenError,
   RateLimitError as HospitableRateLimitError,
+  NotFoundError as HospitableNotFoundError,
   ValidationError as HospitableValidationError,
   ServerError as HospitableServerError,
+  ConfigurationError as HospitableConfigurationError,
 } from './errors'
 
 export * from './models/index'


### PR DESCRIPTION
## Summary

Resolves all 14 issues opened against the 0.7.0 review audit. Includes code fixes, test additions, and documentation updates across 37 files. No Public-API breaking changes.

**Scope:**
- P0: Connect `onTokenExpired` hook, webhook signature verification, AGENTS.md TDD compliance across 10 Connect suites
- P1: `HospitableAuthError` catches 403, `.name` aligned with spec aliases, PII masked in examples, `ConnectFilter` field validation, `*ListParams` type tightening
- P2: `collectAll` re-export, exponential-backoff assertion, filter special-char tests, realistic webhook fixtures, token expiry configurable, URL-keyed mocks

See `CHANGELOG.md` (Unreleased section) for the full itemization.

## Behavior change note

Error `.name` now reports the `Hospitable*` alias (e.g. `'HospitableAuthError'` instead of `'AuthenticationError'`). Code routing on `instanceof` continues to work; code routing on the literal string needs to update.

## Test plan

- [x] `npm run test` — 723 passed (38 files, 723 tests)
- [x] `npm run test -- --coverage` — statements 98.14%, branches 95.71%, functions 99.19%, lines 98.43% (all above the 95% AGENTS.md threshold)
- [ ] Review and merge; confirm downstream consumers' CI on a 0.7.1 tag.

## Closes

Fixes #42
Fixes #43
Fixes #44
Fixes #45
Fixes #46
Fixes #47
Fixes #48
Fixes #49
Fixes #50
Fixes #51
Fixes #52
Fixes #53
Fixes #54
Fixes #55