### PR TITLE
Fix envelope unwrap drift on reservations + inquiries (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 with the caveat that **while at 0.x, breaking changes land on the minor version**
 (standard npm semver for pre-1.0 libraries).
 
+## [Unreleased]
+
+### 🐛 Fixed
+
+- **Envelope unwrap drift on single-resource Reservation/Inquiry endpoints**
+  ([GH#57](https://github.com/kacao/hospitable/issues/57)) — five endpoints
+  were typed against the bare resource (`Reservation` / `Inquiry`) and
+  returned the raw `{ data: ... }` envelope to callers, leaving every
+  top-level field (`id`, `arrivalDate`, etc.) `undefined`. Since the
+  malformed payload deserialized cleanly as `Partial<Resource>`, the bug
+  was silent — downstream consumers reading `result.id` saw `undefined`
+  rather than a thrown error. Other resource `.get()` methods (properties,
+  transactions, payouts, user, calendar, knowledge-hub, listEnrichment,
+  Connect-side everywhere) already unwrapped correctly; this was drift on
+  five sites only:
+  - `client.reservations.get(id)` — `GET /v2/reservations/{id}`
+  - `client.reservations.cancel(uuid, initiatedBy)` — `POST /v2/reservations/{uuid}/cancel`
+  - `client.reservations.create(params)` — `POST /v2/reservations`
+  - `client.reservations.update(uuid, params)` — `PUT /v2/reservations/{uuid}`
+  - `client.inquiries.get(uuid)` — `GET /v2/inquiries/{uuid}`
+
+  **Behavior change**: callers that previously read `result.data?.id` as
+  a workaround will now find `result.data` is undefined; read `result.id`
+  directly. Callers that read `result.id` and saw `undefined` will now
+  see the correct UUID.
+
+  Existing unit tests mocked the *bare* resource shape, so they passed
+  against the broken SDK — that mock-shape drift was itself a bug. Tests
+  now mock the canonical `{ data: ... }` envelope and a regression test
+  per fixed method explicitly asserts `result.id` is populated and
+  `result.data` is absent.
+
+### 🔍 Known but unverified
+
+- `client.reservations.getEnrichment(uuid, key)` and
+  `client.reservations.updateEnrichment(uuid, key, value)` are typed
+  against bare `EnrichmentField` while the sibling `listEnrichment` is
+  enveloped — symmetric inference says these are also drift, but the
+  Hospitable Stoplight bundle does not document the per-key endpoint and
+  no probe script has empirically captured the response shape. Holding
+  the fix until a live-API probe confirms.
+  See [GH#57 follow-up](https://github.com/kacao/hospitable/issues/57).
+
 ## [0.7.2] — 2026-04-25
 
 ### ✨ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 with the caveat that **while at 0.x, breaking changes land on the minor version**
 (standard npm semver for pre-1.0 libraries).
 
-## [Unreleased]
+## [0.7.3] — 2026-04-28
 
 ### 🐛 Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hospitable",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "author": "Khanh Cao <tyrocium@gmail.com>",
   "repository": {
     "type": "git",

--- a/src/__tests__/inquiries.test.ts
+++ b/src/__tests__/inquiries.test.ts
@@ -200,7 +200,7 @@ describe('InquiriesResource', () => {
   describe('get()', () => {
     it('should call GET /v2/inquiries/{uuid} without include when not provided', async () => {
       const inquiry = makeInquiry()
-      vi.mocked(http.get).mockResolvedValue(inquiry)
+      vi.mocked(http.get).mockResolvedValue({ data: inquiry })
 
       const result = await resource.get('6f58fd0a-a9cb-3746-9219-384a156ff7bb')
 
@@ -208,11 +208,11 @@ describe('InquiriesResource', () => {
         '/v2/inquiries/6f58fd0a-a9cb-3746-9219-384a156ff7bb',
         undefined,
       )
-      expect(result).toBe(inquiry)
+      expect(result).toEqual(inquiry)
     })
 
     it('should pass include param when provided', async () => {
-      vi.mocked(http.get).mockResolvedValue(makeInquiry())
+      vi.mocked(http.get).mockResolvedValue({ data: makeInquiry() })
 
       await resource.get('uuid-1', 'guest,properties,messages')
 
@@ -224,12 +224,26 @@ describe('InquiriesResource', () => {
     it('should normalize the fetched inquiry (aliases properties → property)', async () => {
       const property = makeProperty()
       const inquiry = makeInquiry({ properties: property })
-      vi.mocked(http.get).mockResolvedValue(inquiry)
+      vi.mocked(http.get).mockResolvedValue({ data: inquiry })
 
       const result = await resource.get('uuid-1', 'properties')
 
       expect(result.property).toBe(property)
       expect(result.properties).toBe(property)
+    })
+
+    // Regression for the silent envelope-drift bug where `get()` typed the
+    // response as bare `Inquiry` and returned the `{ data: ... }` wrapper
+    // as if it were the resource — leaving `result.id` undefined and
+    // breaking downstream consumers that read it. See GH#57.
+    it('unwraps the { data } envelope so the resource is returned at the top level', async () => {
+      const inquiry = makeInquiry({ id: 'inq-99' })
+      vi.mocked(http.get).mockResolvedValue({ data: inquiry })
+
+      const result = await resource.get('inq-99')
+
+      expect(result.id).toBe('inq-99')
+      expect((result as unknown as { data?: unknown }).data).toBeUndefined()
     })
 
     it('throws NotFoundError on 404', async () => {
@@ -297,7 +311,7 @@ describe('InquiriesResource', () => {
 
     it('should cache get results when cache is enabled', async () => {
       const cachedResource = new InquiriesResource(http, { enabled: true })
-      vi.mocked(http.get).mockResolvedValue(makeInquiry())
+      vi.mocked(http.get).mockResolvedValue({ data: makeInquiry() })
 
       await cachedResource.get('uuid-1')
       await cachedResource.get('uuid-1')

--- a/src/__tests__/reservations.test.ts
+++ b/src/__tests__/reservations.test.ts
@@ -265,17 +265,17 @@ describe('ReservationsResource', () => {
   describe('get()', () => {
     it('calls GET /v2/reservations/{id}', async () => {
       const res = makeReservation({ id: 'res-42' })
-      vi.mocked(http.get).mockResolvedValue(res)
+      vi.mocked(http.get).mockResolvedValue({ data: res })
 
       const result = await resource.get('res-42')
 
       expect(http.get).toHaveBeenCalledWith('/v2/reservations/res-42', undefined)
-      expect(result).toBe(res)
+      expect(result).toEqual(res)
     })
 
     it('passes include param when provided', async () => {
       const res = makeReservation()
-      vi.mocked(http.get).mockResolvedValue(res)
+      vi.mocked(http.get).mockResolvedValue({ data: res })
 
       await resource.get('res-1', 'guest,review')
 
@@ -283,6 +283,20 @@ describe('ReservationsResource', () => {
         '/v2/reservations/res-1',
         { include: 'guest,review' },
       )
+    })
+
+    // Regression for the silent envelope-drift bug where `get()` typed the
+    // response as bare `Reservation` and returned the `{ data: ... }`
+    // wrapper as if it were the resource — leaving `result.id` undefined
+    // and breaking downstream NOT NULL inserts. See GH#57.
+    it('unwraps the { data } envelope so the resource is returned at the top level', async () => {
+      const res = makeReservation({ id: 'res-99' })
+      vi.mocked(http.get).mockResolvedValue({ data: res })
+
+      const result = await resource.get('res-99')
+
+      expect(result.id).toBe('res-99')
+      expect((result as unknown as { data?: unknown }).data).toBeUndefined()
     })
   })
 
@@ -438,7 +452,7 @@ describe('ReservationsResource', () => {
   describe('cancel()', () => {
     it('calls POST /v2/reservations/{uuid}/cancel with initiatedBy', async () => {
       const res = makeReservation({ id: 'res-42', status: 'cancelled' })
-      vi.mocked(http.post).mockResolvedValue(res)
+      vi.mocked(http.post).mockResolvedValue({ data: res })
 
       const result = await resource.cancel('res-42', 'host')
 
@@ -455,10 +469,21 @@ describe('ReservationsResource', () => {
           { category: 'Cancelled', status: 'canceled', changedAt: '2026-01-01T00:00:00+00:00' },
         ],
       })
-      vi.mocked(http.post).mockResolvedValue(res)
+      vi.mocked(http.post).mockResolvedValue({ data: res })
 
       const result = await resource.cancel('res-1', 'guest')
       expect(result.statusHistory[0]!.status).toBe('cancelled')
+    })
+
+    // Regression: same envelope-drift class as get() — see GH#57.
+    it('unwraps the { data } envelope from the cancel response', async () => {
+      const res = makeReservation({ id: 'res-77' })
+      vi.mocked(http.post).mockResolvedValue({ data: res })
+
+      const result = await resource.cancel('res-77', 'host')
+
+      expect(result.id).toBe('res-77')
+      expect((result as unknown as { data?: unknown }).data).toBeUndefined()
     })
 
     it('propagates ValidationError on 422', async () => {
@@ -492,7 +517,7 @@ describe('ReservationsResource', () => {
 
     it('calls POST /v2/reservations with params', async () => {
       const res = makeReservation({ id: 'new-res' })
-      vi.mocked(http.post).mockResolvedValue(res)
+      vi.mocked(http.post).mockResolvedValue({ data: res })
 
       const result = await resource.create(createParams)
 
@@ -506,10 +531,21 @@ describe('ReservationsResource', () => {
           { category: 'Accepted', status: 'canceled', changedAt: '2026-01-01T00:00:00+00:00' },
         ],
       })
-      vi.mocked(http.post).mockResolvedValue(res)
+      vi.mocked(http.post).mockResolvedValue({ data: res })
 
       const result = await resource.create(createParams)
       expect(result.statusHistory[0]!.status).toBe('cancelled')
+    })
+
+    // Regression: same envelope-drift class as get() — see GH#57.
+    it('unwraps the { data } envelope from the 201 response', async () => {
+      const res = makeReservation({ id: 'created-id' })
+      vi.mocked(http.post).mockResolvedValue({ data: res })
+
+      const result = await resource.create(createParams)
+
+      expect(result.id).toBe('created-id')
+      expect((result as unknown as { data?: unknown }).data).toBeUndefined()
     })
 
     it('propagates ValidationError on 422', async () => {
@@ -537,7 +573,7 @@ describe('ReservationsResource', () => {
 
     it('calls PUT /v2/reservations/{uuid} with params', async () => {
       const res = makeReservation({ id: 'res-42' })
-      vi.mocked(http.put).mockResolvedValue(res)
+      vi.mocked(http.put).mockResolvedValue({ data: res })
 
       const result = await resource.update('res-42', updateParams)
 
@@ -554,10 +590,21 @@ describe('ReservationsResource', () => {
           { category: 'Cancelled', status: 'canceled', changedAt: '2026-01-01T00:00:00+00:00' },
         ],
       })
-      vi.mocked(http.put).mockResolvedValue(res)
+      vi.mocked(http.put).mockResolvedValue({ data: res })
 
       const result = await resource.update('res-1', updateParams)
       expect(result.statusHistory[0]!.status).toBe('cancelled')
+    })
+
+    // Regression: same envelope-drift class as get() — see GH#57.
+    it('unwraps the { data } envelope from the update response', async () => {
+      const res = makeReservation({ id: 'updated-id' })
+      vi.mocked(http.put).mockResolvedValue({ data: res })
+
+      const result = await resource.update('updated-id', updateParams)
+
+      expect(result.id).toBe('updated-id')
+      expect((result as unknown as { data?: unknown }).data).toBeUndefined()
     })
 
     it('propagates ValidationError on 422', async () => {
@@ -738,6 +785,39 @@ describe('ReservationsResource', () => {
       const secondCall = vi.mocked(http.get).mock.calls[1]!
       const params = secondCall[1] as Record<string, unknown>
       expect(params['page']).toBe(2)
+    })
+  })
+
+  describe('caching', () => {
+    it('should cache list results when cache is enabled', async () => {
+      const cachedResource = new ReservationsResource(http, { enabled: true })
+      vi.mocked(http.get).mockResolvedValue(makeList([]))
+
+      await cachedResource.list({ properties: ['prop-1'] })
+      await cachedResource.list({ properties: ['prop-1'] })
+
+      expect(http.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('should cache get results when cache is enabled', async () => {
+      const cachedResource = new ReservationsResource(http, { enabled: true })
+      vi.mocked(http.get).mockResolvedValue({ data: makeReservation() })
+
+      await cachedResource.get('res-1')
+      await cachedResource.get('res-1')
+
+      expect(http.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('should bypass cache after clearCache()', async () => {
+      const cachedResource = new ReservationsResource(http, { enabled: true })
+      vi.mocked(http.get).mockResolvedValue(makeList([]))
+
+      await cachedResource.list({ properties: ['prop-1'] })
+      cachedResource.clearCache()
+      await cachedResource.list({ properties: ['prop-1'] })
+
+      expect(http.get).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/src/resources/inquiries.ts
+++ b/src/resources/inquiries.ts
@@ -86,6 +86,10 @@ export class InquiriesResource {
    * `financials`, `guest`, `properties`, `listings`, `messages`. Note that
    * `messages` is only supported on this endpoint, not on {@link list}.
    *
+   * **Envelope quirk**: unlike the list endpoint, the single-inquiry
+   * response is wrapped in `{data: Inquiry}`. The SDK unwraps it so
+   * callers always receive a bare {@link Inquiry}.
+   *
    * @see GET https://public.api.hospitable.com/v2/inquiries/{uuid}
    * @throws {NotFoundError} on 404 (inquiry does not exist)
    * @throws {HospitableError} on 410 (inquiry has been deleted upstream)
@@ -97,11 +101,11 @@ export class InquiriesResource {
       const cached = this.cache.get(key) as Inquiry | undefined
       if (cached) return cached
     }
-    const result = await this.http.get<Inquiry>(
+    const response = await this.http.get<{ data: Inquiry }>(
       `/v2/inquiries/${encodeURIComponent(uuid)}`,
       include ? { include } : undefined,
     )
-    const normalized = normalizeInquiry(result)
+    const normalized = normalizeInquiry(response.data)
     this.cache?.set(key, normalized)
     return normalized
   }

--- a/src/resources/reservations.ts
+++ b/src/resources/reservations.ts
@@ -130,6 +130,12 @@ export class ReservationsResource {
   /**
    * Fetch a single reservation by UUID.
    *
+   * **Envelope quirk**: unlike the list endpoint, the single-reservation
+   * response is wrapped in `{data: Reservation}`. The SDK unwraps it so
+   * callers always receive a bare {@link Reservation}. Mutating endpoints
+   * ({@link cancel}, {@link create}, {@link update}) wrap their responses
+   * the same way and unwrap identically.
+   *
    * @see GET https://public.api.hospitable.com/v2/reservations/{id}
    * @throws {NotFoundError} on 404
    */
@@ -139,11 +145,11 @@ export class ReservationsResource {
       const cached = this.cache.get(key) as Reservation | undefined
       if (cached) return cached
     }
-    const raw = await this.http.get<Reservation>(
+    const response = await this.http.get<{ data: Reservation }>(
       `/v2/reservations/${encodeURIComponent(id)}`,
       include ? { include } : undefined,
     )
-    const result = normalizeReservation(raw)
+    const result = normalizeReservation(response.data)
     this.cache?.set(key, result)
     return result
   }
@@ -239,11 +245,11 @@ export class ReservationsResource {
    * @see POST https://public.api.hospitable.com/v2/reservations/{uuid}/cancel
    */
   async cancel(uuid: string, initiatedBy: CancelReservationInitiatedBy): Promise<Reservation> {
-    const raw = await this.http.post<Reservation>(
+    const response = await this.http.post<{ data: Reservation }>(
       `/v2/reservations/${encodeURIComponent(uuid)}/cancel`,
       { initiatedBy },
     )
-    return normalizeReservation(raw)
+    return normalizeReservation(response.data)
   }
 
   /**
@@ -252,8 +258,8 @@ export class ReservationsResource {
    * @see POST https://public.api.hospitable.com/v2/reservations
    */
   async create(params: CreateReservationParams): Promise<Reservation> {
-    const raw = await this.http.post<Reservation>('/v2/reservations', params)
-    return normalizeReservation(raw)
+    const response = await this.http.post<{ data: Reservation }>('/v2/reservations', params)
+    return normalizeReservation(response.data)
   }
 
   /**
@@ -262,11 +268,11 @@ export class ReservationsResource {
    * @see PUT https://public.api.hospitable.com/v2/reservations/{uuid}
    */
   async update(uuid: string, params: UpdateReservationParams): Promise<Reservation> {
-    const raw = await this.http.put<Reservation>(
+    const response = await this.http.put<{ data: Reservation }>(
       `/v2/reservations/${encodeURIComponent(uuid)}`,
       params,
     )
-    return normalizeReservation(raw)
+    return normalizeReservation(response.data)
   }
 
   /**


### PR DESCRIPTION
## Summary

Five SDK methods (`reservations.get/cancel/create/update`, `inquiries.get`) were typed against bare resources but the Hospitable Public API wraps single-resource responses in `{ data: Resource }`. Result: SDK callers received the envelope shaped as the resource — every top-level field (`id`, `arrivalDate`, etc.) `undefined` — silently corrupting downstream `NOT NULL` inserts on consumer apps.

Other resources (`properties`, `transactions`, `payouts`, `user`, `calendar`, `knowledge-hub`, `listEnrichment`, all Connect-side) already unwrapped correctly. This was drift on five sites only.

Fixes #57.

## Why it was silent

The existing unit tests **masked the bug**: they mocked `http.{get,post,put}` returning a *bare* `Reservation`/`Inquiry`, so mocks and the broken SDK were self-consistent. Tests passed against fixtures that didn't reflect the wire contract — classic mock-shape drift.

## What changed

**Source (5 sites):**
- `src/resources/reservations.ts` — `get()`, `cancel()`, `create()`, `update()` now type as `<{ data: Reservation }>` and unwrap with `response.data`
- `src/resources/inquiries.ts` — `get()` now types as `<{ data: Inquiry }>` and unwraps

**Tests:**
- 12 mock-shape corrections across `src/__tests__/reservations.test.ts` and `src/__tests__/inquiries.test.ts`
- +5 explicit envelope-unwrap regression tests (one per fixed method); each asserts `result.id` is populated AND `result.data` is `undefined`
- Added `caching` describe block for `ReservationsResource.get` parallel to `inquiries.test.ts:287` (existing coverage gap surfaced by review)
- Replaced fragile `.toBe(res)` reference-equality assertions with `.toEqual(res)` to decouple from `normalizeReservation`'s identity-preservation behavior

**Docs:**
- CHANGELOG `[Unreleased]` entry flagging behavior change; lists all five sites
- JSDoc envelope-quirk note on `reservations.get` + `inquiries.get` matching the existing pattern on `properties.get:83-86`

## Behavior change

Callers reading `result.data?.id` as a workaround will now find `result.data` is `undefined`; read `result.id` directly. Callers reading `result.id` and seeing `undefined` will now see the correct UUID.

## Out of scope (follow-ups)

- **`getEnrichment` / `updateEnrichment`** show the same suspicious bare-typing pattern but the per-key endpoints lack an API doc. The CHANGELOG flags them as "Known but unverified" pending an empirical probe — a write→wait→read script that captures the actual response shape before patching.
- **HTTP layer hardening**: when the response body is missing the expected envelope key, a raw `TypeError` propagates instead of a `HospitableError`. Not a leak (no PII in the message), but a DX miss — worth a separate issue.
- **Pre-existing extra-field smuggling**: `normalize*` functions are pass-through (no allowlist). Compromised upstream could inject extra fields. Architectural change (zod/io-ts), not in scope here.

## Review

Three-lane parallel review (code / test / security) found no `[HIGH]`-severity issues. The two `[HIGH]`-confidence test findings (fragile `.toBe(res)` and missing `caching` block for `reservations.get`) are addressed in this PR. Other findings are deferred per "Out of scope" above.

## Test plan

- [x] `npm run test` — 735/735 pass (+8 from baseline 727: 5 envelope regressions + 3 caching tests)
- [x] `npx tsc --noEmit` — clean
- [x] Coverage thresholds (95% statements/branches/functions/lines) hold
- [ ] Manual smoke against live Hospitable API — recommend before tagging the next minor